### PR TITLE
Fix vnet_id OpenAPI mismatch

### DIFF
--- a/sonic_api.yaml
+++ b/sonic_api.yaml
@@ -588,7 +588,7 @@ paths:
       description: Returns attributes for vlans of requested vnet_id. If the vnet_id does not exist, it returns a '404' error.
       parameters:
         - name: vnet_id
-          in: path
+          in: query
           type: string
           required: true
           description: vnet_id containing the vnet guid as a string


### PR DESCRIPTION
The default.go code is taking vnet_id as a query parameter, but the OpenAPI spec says vnet_id is a path param. Fix it to match the code.

Semantic error at paths./config/interface/vlans.get.parameters.0.name
Path parameter "vnet_id" must have the corresponding {vnet_id} segment in the "/config/interface/vlans" path