### PR TITLE
Check prefix length while creating VLAN

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -322,7 +322,7 @@ func ConfigInterfaceVlanPost(w http.ResponseWriter, r *http.Request) {
             if adv_prefix == "true" {
                 ip, network, _ := net.ParseCIDR(attr.IPPrefix)
                 prefix_len, _ := network.Mask.Size()
-                if isV4orV6(ip) == 4 {
+                if isV4orV6(ip.String()) == 4 {
                     if prefix_len < 18 {
                         WriteRequestError(w, http.StatusBadRequest, "Prefix length lesser than 18 not supported", []string{}, "")
                         return                        

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -303,7 +303,39 @@ func ConfigInterfaceVlanPost(w http.ResponseWriter, r *http.Request) {
              return
         }
     }
-
+    /*
+    if advertise_prefix is set for the Vnet then,
+    only all /18 and above for v4 and /64 only for v6
+    */
+    if attr.IPPrefix != "" {
+        vlan_intf_kv, err := GetKVs(db.db_num, generateDBTableKey(db.separator, VLAN_INTF_TB, vlan_name))
+        if err != nil {
+            WriteRequestError(w, http.StatusInternalServerError, "Internal service error", []string{}, "")
+            return
+        }
+        kv, err := GetKVs(db.db_num, generateDBTableKey(db.separator, VNET_TB, vlan_intf_kv["vnet_name"]))
+        if err != nil {
+            WriteRequestError(w, http.StatusInternalServerError, "Internal service error", []string{}, "")
+            return
+        }
+        if adv_prefix, ok := kv["advertise_prefix"]; ok {
+            if adv_prefix == "true" {
+                ip, network, _ := net.ParseCIDR(attr.IPPrefix)
+                prefix_len, _ := network.Mask.Size()
+                if isV4orV6(ip) == 4 {
+                    if prefix_len < 18 {
+                        WriteRequestError(w, http.StatusBadRequest, "Prefix length lesser than 18 not supported", []string{}, "")
+                        return                        
+                    }
+                } else {
+                    if prefix_len != 64 {
+                        WriteRequestError(w, http.StatusBadRequest, "Prefix length other than than 64 not supported", []string{}, "")
+                        return                        
+                    }
+                }
+            }
+        }    
+    }
      /* Creation sequence:  1. Vlan, 2. Vlan Interface table, 3. Vlan Interface IP prefix table 4. Add local subnet route */
      /* Create 1 */
      vlan_pt := swsscommon.NewTable(db.swss_db, VLAN_TB)

--- a/go-server-server/go/persistent.go
+++ b/go-server-server/go/persistent.go
@@ -4,6 +4,7 @@ import (
     "fmt"
     "github.com/go-redis/redis/v7"
     "log"
+    "net"
     "strconv"
     "strings"
     "swsscommon"
@@ -491,4 +492,12 @@ func generateDBTableKey(separator string, vars ...string) (string) {
          }
     }
     return buf.String()
+}
+
+func isV4orV6(ipaddr string) (int) {
+    ip, _ := net.ParseIP(string)
+    if ip.To4() != nil {
+        return 4
+    }
+    return 6
 }

--- a/go-server-server/go/persistent.go
+++ b/go-server-server/go/persistent.go
@@ -4,7 +4,6 @@ import (
     "fmt"
     "github.com/go-redis/redis/v7"
     "log"
-    "net"
     "strconv"
     "strings"
     "swsscommon"
@@ -492,12 +491,4 @@ func generateDBTableKey(separator string, vars ...string) (string) {
          }
     }
     return buf.String()
-}
-
-func isV4orV6(ipaddr string) (int) {
-    ip, _ := net.ParseIP(string)
-    if ip.To4() != nil {
-        return 4
-    }
-    return 6
 }

--- a/go-server-server/go/util.go
+++ b/go-server-server/go/util.go
@@ -130,6 +130,14 @@ func IsValidIPBoth(ipstr string) bool {
     return ip != nil
 }
 
+func isV4orV6(ipaddr string) (int) {
+    ip := net.ParseIP(ipaddr)
+    if ip.To4() != nil {
+        return 4
+    }
+    return 6
+}
+
 func ParseIPBothPrefix(ipprefix string) (ipstr string, length int, err error) {
     ip, net, err := net.ParseCIDR(ipprefix)
     if err != nil {


### PR DESCRIPTION
Allow only prefixes with length greater than /18 for v4 and equal to /64 for v6