### PR TITLE
Check prefix length while configuring route

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -967,6 +967,7 @@ func ConfigVrouterVrfIdDelete(w http.ResponseWriter, r *http.Request) {
 
     pt.Del(vnet_id_str, "DEL", "")
     CacheDeleteVnetGuidId(vars["vnet_name"])
+    CacheDeletePrefixAdv(vnet_id_str)
 
     w.WriteHeader(http.StatusNoContent)
 }

--- a/go-server-server/go/persistent.go
+++ b/go-server-server/go/persistent.go
@@ -472,6 +472,11 @@ func CacheSetPrefixAdv(vnet_id_str string, adv_prefix string) {
     return
 }
 
+func CacheDeletePrefixAdv(vnet_id_str string) {
+    delete(vnetAdvPrefixMap, vnet_id_str)
+    return
+}
+
 func CacheGenAndSetVnetGuidId(GUID string, VNI uint32) (val uint32) {
     vnetGuidMap[GUID] = nextGuidId
     vniVnetMap[VNI] = GUID

--- a/go-server-server/go/persistent.go
+++ b/go-server-server/go/persistent.go
@@ -29,6 +29,7 @@ var vniVnetMap map[uint32]string
 var vnetGuidIdUsed []bool
 var nextGuidId uint32
 var localTunnelLpbkIps []string
+var vnetAdvPrefixMap map[string]string
 
 const REDIS_SOCK string = "/var/run/redis/redis.sock"
 
@@ -110,6 +111,7 @@ func InitialiseVariables() {
     genVnetGuidMap()
 
     genVxlanTunnelInfo()
+    vnetAdvPrefixMap = make(map[string]string)
 }
 
 func genVnetGuidMap() {
@@ -444,6 +446,29 @@ func CacheGetVnetGuidId(GUID string) (val uint32) {
 
 func CacheGetVniId(VNI uint32) (val string) {
     val = vniVnetMap[VNI]
+    return
+}
+
+func CacheGetPrefixAdv(vnet_id_str string) (adv_prefix string, found bool) {
+    adv_prefix = ""
+    found = false
+    if adv_prefix, found = vnetAdvPrefixMap[vnet_id_str]; found {
+        return
+    } else {
+        db := &conf_db_ops
+        kv, err := GetKVs(db.db_num, generateDBTableKey(db.separator, VNET_TB, vnet_id_str))
+        if err != nil {
+            return
+        }
+        if adv_prefix, found := kv["advertise_prefix"]; found {
+            vnetAdvPrefixMap[vnet_id_str] = adv_prefix
+        }
+    }
+    return
+}
+
+func CacheSetPrefixAdv(vnet_id_str string, adv_prefix string) {
+    vnetAdvPrefixMap[vnet_id_str] = adv_prefix
     return
 }
 

--- a/go-server-server/go/util.go
+++ b/go-server-server/go/util.go
@@ -130,6 +130,14 @@ func IsValidIPBoth(ipstr string) bool {
     return ip != nil
 }
 
+func isV4orV6(ipaddr string) (int) {
+    ip := net.ParseIP(ipaddr)
+    if ip.To4() != nil {
+        return 4
+    }
+    return 6
+}
+
 func ParseIPBothPrefix(ipprefix string) (ipstr string, length int, err error) {
     ip, net, err := net.ParseCIDR(ipprefix)
     if err != nil {


### PR DESCRIPTION
Allow only prefixes with length greater than /18 for v4 and equal to /64 for v6