### PR TITLE
[Static Route Expiry] Feature support

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1561,8 +1561,7 @@ func ConfigVrfVrfIdRoutesGet(w http.ResponseWriter, r *http.Request) {
 
     routes := []RouteModel{}
     for k, kvp := range kv {
-        ipprefix := strings.Split(k, db.separator)[2]
-
+        ipprefix, _ := ExtractIPAddressFromKey(k, db.separator)
         routeModel := RouteModel{
             IPPrefix:    ipprefix,
             NextHop:     kvp["nexthop"],

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1561,7 +1561,7 @@ func ConfigVrfVrfIdRoutesGet(w http.ResponseWriter, r *http.Request) {
 
     routes := []RouteModel{}
     for k, kvp := range kv {
-        ipprefix, _ := ExtractIPAddressFromKey(k, db.separator)
+        ipprefix, _ := ExtractIPPrefixFromKey(k, db.separator)
         routeModel := RouteModel{
             IPPrefix:    ipprefix,
             NextHop:     kvp["nexthop"],

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1461,22 +1461,21 @@ func ConfigVrfVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
 
 func ConfigVrfStaticRouteExpiryPost(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-    vars := mux.Vars(r)
     db := &app_db_ops
 
+    var attr StaticRouteExpiryTimeModel
     ReadJSONBody(w, r, &attr)
 
     static_rt_t := swsscommon.NewTable(db.swss_db, STATIC_ROUTE_TB)
     defer static_rt_t.Delete()
 
     static_rt_t.Set("EXPIRY_TIME", map[string]string {
-                        "time": attr.Time,
+                        "time": strconv.Itoa(attr.Time),
         }, "SET", "")
     w.WriteHeader(http.StatusNoContent)    
 }
 
 func ConfigVrfStaticRouteExpiryGet(w http.ResponseWriter, r *http.Request) {
-    vars := mux.Vars(r)
     db := &app_db_ops
 
     kv, err := GetKVs(db.db_num, generateDBTableKey(db.separator, STATIC_ROUTE_TB, "EXPIRY_TIME"))
@@ -1486,12 +1485,13 @@ func ConfigVrfStaticRouteExpiryGet(w http.ResponseWriter, r *http.Request) {
     }
 
     if len(kv) == 0 {
-        WriteRequestError(w, http.StatusBadRequest, "Object does not exist!")
+        WriteRequestError(w, http.StatusBadRequest, "Object does not exist!", []string{}, "")
         return
     }
 
+    time, _ := strconv.Atoi(kv["time"])
     output := StaticRouteExpiryTimeModel {
-        Time: kv["time"],
+        Time: time,
     }
     WriteRequestResponse(w, output, http.StatusOK)
 }

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1473,11 +1473,11 @@ func ConfigVrfVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
     }
 }
 
-func ConfigVrfStaticRouteExpiryPost(w http.ResponseWriter, r *http.Request) {
+func ConfigVrfRouteExpiryPost(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Content-Type", "application/json; charset=UTF-8")
     db := &app_db_ops
 
-    var attr StaticRouteExpiryTimeModel
+    var attr RouteExpiryTimeModel
     err := ReadJSONBody(w, r, &attr)
     if err != nil {
         // The error is already handled in this case
@@ -1493,7 +1493,7 @@ func ConfigVrfStaticRouteExpiryPost(w http.ResponseWriter, r *http.Request) {
     w.WriteHeader(http.StatusNoContent)    
 }
 
-func ConfigVrfStaticRouteExpiryGet(w http.ResponseWriter, r *http.Request) {
+func ConfigVrfRouteExpiryGet(w http.ResponseWriter, r *http.Request) {
     db := &app_db_ops
 
     kv, err := GetKVs(db.db_num, generateDBTableKey(db.separator, STATIC_ROUTE_EXP_TB))
@@ -1508,7 +1508,7 @@ func ConfigVrfStaticRouteExpiryGet(w http.ResponseWriter, r *http.Request) {
     }
 
     time, _ := strconv.Atoi(kv["time"])
-    output := StaticRouteExpiryTimeModel {
+    output := RouteExpiryTimeModel {
         Time: time,
     }
     WriteRequestResponse(w, output, http.StatusOK)

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1432,7 +1432,9 @@ func ConfigVrfVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
                     pt.Del(generateDBTableKey(db.separator,vrf_id_str, r.IPPrefix), "DEL", "")
                 } else {
                     /* Identical route */
-                    continue
+                    if r.Persistent == "true" {
+                        continue
+                    }
                 }
             }
             route_map := make(map[string]string)

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1459,6 +1459,12 @@ func ConfigVrfVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
     }
 }
 
+func ConfigVrfVrfIdRouteExpiryGet(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+    vars := mux.Vars(r)
+    vrf_id_str := vars["vrf_id"]
+}
+
 func ConfigVrfVrfIdRoutesGet(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Content-Type", "application/json; charset=UTF-8")
     vars := mux.Vars(r)

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1470,10 +1470,10 @@ func ConfigVrfStaticRouteExpiryPost(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-    static_rt_t := swsscommon.NewTable(db.swss_db, STATIC_ROUTE_TB)
+    static_rt_t := swsscommon.NewTable(db.swss_db, STATIC_ROUTE_EXP_TB)
     defer static_rt_t.Delete()
 
-    static_rt_t.Set("EXPIRY_TIME", map[string]string {
+    static_rt_t.Set("", map[string]string {
                         "time": strconv.Itoa(attr.Time),
         }, "SET", "")
     w.WriteHeader(http.StatusNoContent)    
@@ -1482,7 +1482,7 @@ func ConfigVrfStaticRouteExpiryPost(w http.ResponseWriter, r *http.Request) {
 func ConfigVrfStaticRouteExpiryGet(w http.ResponseWriter, r *http.Request) {
     db := &app_db_ops
 
-    kv, err := GetKVs(db.db_num, generateDBTableKey(db.separator, STATIC_ROUTE_TB, "EXPIRY_TIME"))
+    kv, err := GetKVs(db.db_num, generateDBTableKey(db.separator, STATIC_ROUTE_EXP_TB, ""))
     if err != nil {
         WriteRequestError(w, http.StatusInternalServerError, "Internal service error", []string{}, "")
         return

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1464,7 +1464,11 @@ func ConfigVrfStaticRouteExpiryPost(w http.ResponseWriter, r *http.Request) {
     db := &app_db_ops
 
     var attr StaticRouteExpiryTimeModel
-    ReadJSONBody(w, r, &attr)
+    err := ReadJSONBody(w, r, &attr)
+    if err != nil {
+        // The error is already handled in this case
+        return
+    }
 
     static_rt_t := swsscommon.NewTable(db.swss_db, STATIC_ROUTE_TB)
     defer static_rt_t.Delete()

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1482,7 +1482,7 @@ func ConfigVrfStaticRouteExpiryPost(w http.ResponseWriter, r *http.Request) {
 func ConfigVrfStaticRouteExpiryGet(w http.ResponseWriter, r *http.Request) {
     db := &app_db_ops
 
-    kv, err := GetKVs(db.db_num, generateDBTableKey(db.separator, STATIC_ROUTE_EXP_TB, ""))
+    kv, err := GetKVs(db.db_num, generateDBTableKey(db.separator, STATIC_ROUTE_EXP_TB))
     if err != nil {
         WriteRequestError(w, http.StatusInternalServerError, "Internal service error", []string{}, "")
         return

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1535,7 +1535,9 @@ func ConfigVrfVrfIdRoutesGet(w http.ResponseWriter, r *http.Request) {
     // Check non-persistent static routes first
     db := &app_db_ops
     var pattern string
+    var persistent bool
 
+    persistent = false
     pattern = generateDBTableKey(db.separator, STATIC_ROUTE_TB, vrf_id_str, ipprefix)
     kv, err := GetKVsMulti(db.db_num, pattern)
     if err != nil {
@@ -1551,7 +1553,8 @@ func ConfigVrfVrfIdRoutesGet(w http.ResponseWriter, r *http.Request) {
         if err != nil {
             WriteRequestError(w, http.StatusInternalServerError, "Internal service error", []string{}, "")
             return
-        }        
+        }      
+        persistent = true  
     }
 
     routes := []RouteModel{}
@@ -1577,6 +1580,9 @@ func ConfigVrfVrfIdRoutesGet(w http.ResponseWriter, r *http.Request) {
 
         if profile, ok := kvp["profile"]; ok {
             routeModel.Profile = profile
+        }
+        if persistent == true {
+            routeModel.Persistent = "true"
         }
         routes = append(routes, routeModel)
     }

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -37,6 +37,7 @@ type RouteModel struct {
     Vnid           int    `json:"vnid,omitempty"`
     Weight         string `json:"weight,omitempty"`
     Profile        string `json:"profile,omitempty"`
+    Persistent     string `json:"persistent,omitempty"`
     Error_code     int    `json:"error_code,omitempty"`
     Error_msg      string `json:"error_msg,omitempty"`
 }
@@ -197,6 +198,7 @@ func (m *RouteModel) UnmarshalJSON(data []byte) (err error) {
         Vnid           int     `json:"vnid"`
         Weight         *string `json:"weight"`
         Profile        *string `json:"profile"`
+        Persistent     *string `json:persistent`
         Error          string  `json:"error"`
     }{}
 
@@ -260,6 +262,17 @@ func (m *RouteModel) UnmarshalJSON(data []byte) (err error) {
             return
         }
         m.MACAddress = *required.MACAddress
+    }
+
+    if required.Persistent == nil {
+        m.Persistent = "false"
+    } else {
+        if strings.Contains(*required.Persistent, "true") || strings.Contains(*required.Persistent, "false") {
+            m.Persistent = *required.Persistent
+        } else {
+            err = &InvalidFormatError{Field: "persistent", Message: "must be either true or false"}
+            return             
+        }
     }
 
     m.Cmd = *required.Cmd

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -391,11 +391,6 @@ func (m *StaticRouteExpiryTimeModel) UnmarshalJSON(data []byte) (err error) {
         return
     }
 
-    if required.Time == nil {
-        err = &MissingValueError{"time"}
-        return
-    }
-
     if required.Time < 0 || required.Time > 1800 {
         err = &InvalidFormatError{Field: "time", Message: "time must be: 0 < time <= 1800"}
         return

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -22,7 +22,7 @@ type BgpProfileModel struct {
     CommunityId  string `json:"community_id"`
 }
 
-type StaticRouteExpiryTimeModel struct {
+type RouteExpiryTimeModel struct {
     Time int `json:"time"`
 }
 
@@ -393,7 +393,7 @@ func (m *VnetModel) UnmarshalJSON(data []byte) (err error) {
     return
 }
 
-func (m *StaticRouteExpiryTimeModel) UnmarshalJSON(data []byte) (err error) {
+func (m *RouteExpiryTimeModel) UnmarshalJSON(data []byte) (err error) {
     required := struct {
         Time int `json:"time"`
     }{}
@@ -404,8 +404,8 @@ func (m *StaticRouteExpiryTimeModel) UnmarshalJSON(data []byte) (err error) {
         return
     }
 
-    if required.Time < 0 || required.Time > 1800 {
-        err = &InvalidFormatError{Field: "time", Message: "time must be greater than 0 and lesser than or equal to 1800"}
+    if required.Time < 0 || required.Time > 172800 {
+        err = &InvalidFormatError{Field: "time", Message: "time must be greater than 0 and lesser than or equal to 172800"}
         return
     }
 

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -392,7 +392,7 @@ func (m *StaticRouteExpiryTimeModel) UnmarshalJSON(data []byte) (err error) {
     }
 
     if required.Time < 0 || required.Time > 1800 {
-        err = &InvalidFormatError{Field: "time", Message: "time must be: 0 < time <= 1800"}
+        err = &InvalidFormatError{Field: "time", Message: "time must be greater than 0 and lesser than or equal to 1800"}
         return
     }
 

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -22,6 +22,10 @@ type BgpProfileModel struct {
     CommunityId  string `json:"community_id"`
 }
 
+type StaticRouteExpiryTimeModel struct {
+    Time int `json:"time"`
+}
+
 type RouteModel struct {
     Cmd            string `json:"cmd,omitempty"`
     IPPrefix       string `json:"ip_prefix"`
@@ -373,6 +377,31 @@ func (m *VnetModel) UnmarshalJSON(data []byte) (err error) {
         }
     }
 
+    return
+}
+
+func (m *StaticRouteExpiryTimeModel) UnmarshalJSON(data []byte) (err error) {
+    required := struct {
+        Time int `json:"time"`
+    }{}
+
+    err = json.Unmarshal(data, &required)
+
+    if err != nil {
+        return
+    }
+
+    if required.Time == nil {
+        err = &MissingValueError{"time"}
+        return
+    }
+
+    if required.Time < 0 || required.Time > 1800 {
+        err = &InvalidFormatError{Field: "time", Message: "time must be: 0 < time <= 1800"}
+        return
+    }
+
+    m.Time = required.Time
     return
 }
 

--- a/go-server-server/go/persistent.go
+++ b/go-server-server/go/persistent.go
@@ -43,19 +43,20 @@ const APPL_CACHE_DB int = 8
 const SWSS_TIMEOUT uint = 0
 
 // DB Table names
-const VXLAN_TUNNEL_TB   string = "VXLAN_TUNNEL"
-const VNET_TB           string = "VNET"
-const VLAN_TB           string = "VLAN"
-const VLAN_INTF_TB      string = "VLAN_INTERFACE"
-const VLAN_MEMB_TB      string = "VLAN_MEMBER"
-const VLAN_NEIGH_TB     string = "NEIGH"
-const ROUTE_TUN_TB      string = "VNET_ROUTE_TUNNEL_TABLE"
-const LOCAL_ROUTE_TB    string = "VNET_ROUTE_TABLE"
-const CFG_ROUTE_TUN_TB  string = "VNET_ROUTE_TUNNEL"
+const VXLAN_TUNNEL_TB       string = "VXLAN_TUNNEL"
+const VNET_TB               string = "VNET"
+const VLAN_TB               string = "VLAN"
+const VLAN_INTF_TB          string = "VLAN_INTERFACE"
+const VLAN_MEMB_TB          string = "VLAN_MEMBER"
+const VLAN_NEIGH_TB         string = "NEIGH"
+const ROUTE_TUN_TB          string = "VNET_ROUTE_TUNNEL_TABLE"
+const LOCAL_ROUTE_TB        string = "VNET_ROUTE_TABLE"
+const CFG_ROUTE_TUN_TB      string = "VNET_ROUTE_TUNNEL"
 const CFG_LOCAL_ROUTE_TB    string = "VNET_ROUTE"
-const CRM_TB            string = "CRM"
-const STATIC_ROUTE_TB   string = "STATIC_ROUTE"
-const BGP_PROFILE_TABLE       string = "BGP_PROFILE_TABLE"
+const CRM_TB                string = "CRM"
+const STATIC_ROUTE_TB       string = "STATIC_ROUTE"
+const STATIC_ROUTE_EXP_TB   string = "STATIC_ROUTE_EXPIRY_TIME"
+const BGP_PROFILE_TABLE     string = "BGP_PROFILE_TABLE"
 
 // DB Helper constants
 const VNET_NAME_PREF  string = "Vnet"

--- a/go-server-server/go/routers.go
+++ b/go-server-server/go/routers.go
@@ -279,6 +279,20 @@ var routes = Routes{
     },
 
     Route{
+        "ConfigVrfVrfIdRouteExpiryGet",
+        "GET",
+        "/v1/config/vrf/{vrf_id}/route_expiry",
+        ConfigVrfVrfIdRouteExpiryGet,
+    },
+
+    Route{
+        "ConfigVrfVrfIdRouteExpiryPost",
+        "POST",
+        "/v1/config/vrf/{vrf_id}/route_expiry",
+        ConfigVrfVrfIdRouteExpiryPost,
+    },
+
+    Route{
         "ConfigVrfVrfIdRoutesGet",
         "GET",
         "/v1/config/vrf/{vrf_id}/routes",

--- a/go-server-server/go/routers.go
+++ b/go-server-server/go/routers.go
@@ -279,17 +279,17 @@ var routes = Routes{
     },
 
     Route{
-        "ConfigVrfVrfIdRouteExpiryGet",
+        "ConfigVrfRouteExpiryGet",
         "GET",
-        "/v1/config/vrf/static_route/route_expiry",
-        ConfigVrfStaticRouteExpiryGet,
+        "/v1/config/vrf/route_expiry",
+        ConfigVrfRouteExpiryGet,
     },
 
     Route{
-        "ConfigVrfVrfIdRouteExpiryPost",
+        "ConfigVrfRouteExpiryPost",
         "POST",
-        "/v1/config/vrf/static_route/route_expiry",
-        ConfigVrfStaticRouteExpiryPost,
+        "/v1/config/vrf/route_expiry",
+        ConfigVrfRouteExpiryPost,
     },
 
     Route{

--- a/go-server-server/go/routers.go
+++ b/go-server-server/go/routers.go
@@ -281,15 +281,15 @@ var routes = Routes{
     Route{
         "ConfigVrfVrfIdRouteExpiryGet",
         "GET",
-        "/v1/config/vrf/{vrf_id}/route_expiry",
-        ConfigVrfVrfIdRouteExpiryGet,
+        "/v1/config/vrf/static_route/route_expiry",
+        ConfigVrfStaticRouteExpiryGet,
     },
 
     Route{
         "ConfigVrfVrfIdRouteExpiryPost",
         "POST",
-        "/v1/config/vrf/{vrf_id}/route_expiry",
-        ConfigVrfVrfIdRouteExpiryPost,
+        "/v1/config/vrf/static_route/route_expiry",
+        ConfigVrfStaticRouteExpiryPost,
     },
 
     Route{

--- a/go-server-server/go/util.go
+++ b/go-server-server/go/util.go
@@ -167,6 +167,23 @@ func ParseIPPrefix(ipprefix string) (ipstr string, length int, err error) {
     return
 }
 
+func ExtractIPAddressFromKey(key string, dbseperator string) (ipprefix string, err error) {
+    ctr := 0
+	var idx int
+	for i, c := range key {
+		if strings.Compare(string(c), dbseperator) == 0 {
+			ctr += 1
+		}
+		if ctr == 2 {
+			idx = i
+			break
+		}
+	}
+	ipprefix = key[idx+1 : len(key)]
+    _, _, err = net.ParseCIDR(ipprefix)
+    return
+}
+
 func ValidateVnid(w http.ResponseWriter, vnidStr string) (vnid int, err error) {
     vnid, err = strconv.Atoi(vnidStr)
     if err != nil {

--- a/go-server-server/go/util.go
+++ b/go-server-server/go/util.go
@@ -167,7 +167,7 @@ func ParseIPPrefix(ipprefix string) (ipstr string, length int, err error) {
     return
 }
 
-func ExtractIPAddressFromKey(key string, dbseperator string) (ipprefix string, err error) {
+func ExtractIPPrefixFromKey(key string, dbseperator string) (ipprefix string, err error) {
     ctr := 0
 	var idx int
 	for i, c := range key {

--- a/sonic_api.yaml
+++ b/sonic_api.yaml
@@ -1512,7 +1512,22 @@ paths:
     patch:
       operationId: ConfigVrfVrfIdRoutesPatch
       summary: Update/modify IP routes for a VRF
-      description: This API call receives a list of route entries to be added/modified/deleted from the virtual routing table defined by 'vrf_id'. API shall operate on default vrf if the 'vrf_id' is specified as 'default'. It is not required by the user to create 'default' vrf. For non-default vrf, if an object with vrf_id doesn't exist this will return an error code '404'. The 'cmd' attribute will determine whether this is an add or delete request. For 'add' operations the API will try to insert every route entry individually. If a route entry already exists in the virtual routing table, the attributes of the rouing entry will be updated. If a route entry doesn't exist in the routing table yet, it will be inserted there. If something went wrong the route entry will be returned as member of "failed" list with "error_code" attr set to some HTTP error code and "error_msg" attr set to some custom error string. Similarly for 'delete' operations the API will try to delete every route entry individually, if the delete fails it will be returned as a member of the "failed" list with attrs "error_code" and "error_msg" set. User can specify if the route must be persitent and saved to config. This is a per-route optional attribute with default set as 'false'. For non-persistent routes, the client is expected to refresh at periodic intervals. If not refreshed, the default expiry is 180 sec and the route gets marked for deletion and later removed in the next cycle. In effect, the non-refreshed route can get removed anytime between 180 - 360 sec. User is not expected to configure a route first as persistent and then as non-persistent or vice versa. In such cases, persistent takes precedence.
+      description: This API call receives a list of route entries to be added/modified/deleted from the virtual 
+      routing table defined by 'vrf_id'. API shall operate on default vrf if the 'vrf_id' is specified as 'default'. 
+      It is not required by the user to create 'default' vrf. For non-default vrf, if an object with vrf_id doesn't 
+      exist this will return an error code '404'. The 'cmd' attribute will determine whether this is an add or delete 
+      request. For 'add' operations the API will try to insert every route entry individually. If a route entry 
+      already exists in the virtual routing table, the attributes of the rouing entry will be updated. If a route 
+      entry doesn't exist in the routing table yet, it will be inserted there. If something went wrong the route 
+      entry will be returned as member of "failed" list with "error_code" attr set to some HTTP error code and 
+      "error_msg" attr set to some custom error string. Similarly for 'delete' operations the API will try to delete 
+      every route entry individually, if the delete fails it will be returned as a member of the "failed" list with 
+      attrs "error_code" and "error_msg" set. User can specify if the route must be persitent and saved to config. 
+      This is a per-route optional attribute with default set as 'false'. For non-persistent routes, the client is 
+      expected to refresh at periodic intervals. If not refreshed, the default expiry is 180 sec and the route gets 
+      marked for deletion and later removed in the next cycle. In effect, the non-refreshed route can get removed 
+      anytime between 180 - 360 sec. User is not expected to configure a route first as persistent and then as non-persistent 
+      or vice versa. In such cases, persistent takes precedence.
       parameters:
         - name: vrf_id
           in: path

--- a/test/restapi_client.py
+++ b/test/restapi_client.py
@@ -192,6 +192,13 @@ class RESTAPI_client:
             params['ip_prefix'] = ip_prefix
         return self.get('v1/config/vrf/{vrf_id}/routes'.format(vrf_id=vrf_id), params=params)
 
+    # Static Route Expiry Timer
+    def get_static_rt_expiry_timer(self):
+        return self.get('v1/config/vrf/static_route/route_expiry')
+
+    def post_static_rt_expiry_timer(self, value):
+        return self.post('v1/config/vrf/static_route/route_expiry', value)
+
     # In memory DB restart
     def post_config_restart_in_mem_db(self):
         return self.post('v1/config/restartdb')

--- a/test/restapi_client.py
+++ b/test/restapi_client.py
@@ -193,11 +193,11 @@ class RESTAPI_client:
         return self.get('v1/config/vrf/{vrf_id}/routes'.format(vrf_id=vrf_id), params=params)
 
     # Static Route Expiry Timer
-    def get_static_rt_expiry_timer(self):
-        return self.get('v1/config/vrf/static_route/route_expiry')
+    def get_rt_expiry_timer(self):
+        return self.get('v1/config/vrf/route_expiry')
 
-    def post_static_rt_expiry_timer(self, value):
-        return self.post('v1/config/vrf/static_route/route_expiry', value)
+    def post_rt_expiry_timer(self, value):
+        return self.post('v1/config/vrf/route_expiry', value)
 
     # In memory DB restart
     def post_config_restart_in_mem_db(self):

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -1266,16 +1266,16 @@ class TestRestApiPositive:
         assert local_route_table == {}
 
     # Static Route Expiry
-    def test_static_route_expiry_post(self, setup_restapi_client):
+    def test_route_expiry_post(self, setup_restapi_client):
         _, _, _, restapi_client = setup_restapi_client
-        r = restapi_client.post_static_rt_expiry_timer({'time': 30})
+        r = restapi_client.post_rt_expiry_timer({'time': 30})
         assert r.status_code == 204
 
-    def test_static_route_expiry_get(self, setup_restapi_client):
+    def test_route_expiry_get(self, setup_restapi_client):
         _, _, _, restapi_client = setup_restapi_client
-        r = restapi_client.post_static_rt_expiry_timer({'time': 30})
+        r = restapi_client.post_rt_expiry_timer({'time': 30})
         assert r.status_code == 204
-        r = restapi_client.get_static_rt_expiry_timer()
+        r = restapi_client.get_rt_expiry_timer()
         assert r.status_code == 200
         j = json.loads(r.text)
         assert j == {
@@ -1788,16 +1788,16 @@ class TestRestApiNegative():
         assert j['error']['details'] == "must be either true or false"
 
     # Static Route Expiry
-    def test_static_route_expiry_post(self, setup_restapi_client):
+    def test_route_expiry_post(self, setup_restapi_client):
         _, _, _, restapi_client = setup_restapi_client
-        r = restapi_client.post_static_rt_expiry_timer({'time': 3000})
+        r = restapi_client.post_rt_expiry_timer({'time': 185000})
         assert r.status_code == 400
         j = json.loads(r.text)
-        assert j['error']['details'] == "time must be greater than 0 and lesser than or equal to 1800"
+        assert j['error']['details'] == "time must be greater than 0 and lesser than or equal to 172800"
 
-    def test_static_route_expiry_get(self, setup_restapi_client):
+    def test_route_expiry_get(self, setup_restapi_client):
         _, _, _, restapi_client = setup_restapi_client
-        r = restapi_client.get_static_rt_expiry_timer()
+        r = restapi_client.get_rt_expiry_timer()
         assert r.status_code == 400
         j = json.loads(r.text)
         assert j['error']['message'] == "Object does not exist!"        

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -1172,6 +1172,23 @@ class TestRestApiPositive:
         local_route_table = db.hgetall(LOCAL_ROUTE_TB + ':' + VNET_NAME_PREF +str(1)+':10.1.1.0/24')
         assert local_route_table == {}
 
+    # Static Route Expiry
+    def test_static_route_expiry_post(self, setup_restapi_client):
+        _, _, _, restapi_client = setup_restapi_client
+        r = restapi_client.post_static_rt_expiry_timer({'time': 30})
+        assert r.status_code == 204
+
+    def test_static_route_expiry_get(self, setup_restapi_client):
+        _, _, _, restapi_client = setup_restapi_client
+        r = restapi_client.post_static_rt_expiry_timer({'time': 30})
+        assert r.status_code == 204
+        r = restapi_client.get_static_rt_expiry_timer()
+        assert r.status_code == 200
+        j = json.loads(r.text)
+        assert j == {
+            'time': 30
+        }
+
     # Operations
     # PingVRF
     def test_post_ping(self, setup_restapi_client):
@@ -1657,6 +1674,21 @@ class TestRestApiNegative():
         del route['nexthop']
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 400
+
+    # Static Route Expiry
+    def test_static_route_expiry_post(self, setup_restapi_client):
+        _, _, _, restapi_client = setup_restapi_client
+        r = restapi_client.post_static_rt_expiry_timer({'time': 3000})
+        assert r.status_code == 400
+        j = json.loads(r.text)
+        assert j['error']['details'] == "time must be greater than 0 and lesser than or equal to 1800"
+
+    def test_static_route_expiry_get(self, setup_restapi_client):
+        _, _, _, restapi_client = setup_restapi_client
+        r = restapi_client.get_static_rt_expiry_timer()
+        assert r.status_code == 400
+        j = json.loads(r.text)
+        assert j['error']['message'] == "Object does not exist!"        
 
     # Operations
     # PingVRF

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -1077,6 +1077,61 @@ class TestRestApiPositive:
         assert r.status_code == 200
         j = json.loads(r.text)
         assert sorted(j) == sorted(routes_cleaned)
+
+    def test_vrf_static_routes_patch(self, setup_restapi_client):
+        _, _, _, restapi_client = setup_restapi_client
+        routes = []
+        routes.append({'cmd':'add',
+                            'ip_prefix':'20.1.2.0/24',
+                            'nexthop':'192.168.2.200',
+                            'persistent': 'true'})
+
+        routes.append({'cmd':'add',
+                            'ip_prefix':'30.1.2.0/24',
+                            'nexthop':'192.168.2.200,192.168.2.201'})
+
+        routes.append({'cmd':'add',
+                            'ip_prefix':'40.1.2.0/24',
+                            'nexthop':'192.168.2.200,192.168.2.201,192.168.2.202',
+                            'ifname':'Ethernet0,Ethernet4,Ethernet8'})
+
+        routes.append({'cmd':'add',
+                            'ip_prefix':'fd30:fc14:8a92:b4d3::/64',
+                            'ifname':'Ethernet0,Ethernet4',
+                            'persistent': 'true'})
+
+        routes.append({'cmd':'add',
+                            'ip_prefix':'60.1.2.0/24',
+                            'ifname':'Ethernet8'})
+
+        routes.append({'cmd':'add',
+                            'ip_prefix':'70.1.2.0/24',
+                            'nexthop':'192.168.2.200,192.168.2.201,192.168.2.202',
+                            'nexthop_monitor':'192.168.3.200,192.168.3.201,192.168.3.202',
+                            'weight':'10,20',
+                            'profile':'profile1'})
+
+        routes.append({'cmd':'add',
+                            'ip_prefix':'fd30:fc14:8a92:b4e3::/64',
+                            'nexthop':'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404',
+                            'nexthop_monitor':'cac4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,a803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404',
+                            'weight':'10,20',
+                            'profile':'profile2'})
+
+
+        # Patch add
+        r = restapi_client.patch_config_vrf_vrf_id_routes("default", routes)
+        assert r.status_code == 204
+
+        for route in routes:
+             del route['cmd']
+             if 'nexthop' not in route:
+                 route['nexthop'] = ''
+
+        r = restapi_client.get_config_vrf_vrf_id_routes("default")
+        assert r.status_code == 200
+        j = json.loads(r.text)
+        assert sorted(j) == sorted(routes)     
         
     def test_vrf_non_persistent_routes_all_verbs(self, setup_restapi_client):
         _, _, _, restapi_client = setup_restapi_client

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -1238,7 +1238,8 @@ class TestRestApiPositive:
                             'nexthop':'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404',
                             'nexthop_monitor':'cac4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,a803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404',
                             'weight':'10,20',
-                            'profile':'profile2'})
+                            'profile':'profile2',
+                            'persistent': 'true'})
 
         routes.append({'cmd':'add',
                             'ip_prefix':'70.1.2.0/24',
@@ -1261,7 +1262,10 @@ class TestRestApiPositive:
         r = restapi_client.get_config_vrf_vrf_id_routes("default")
         assert r.status_code == 200
         j = json.loads(r.text)
-        assert sorted(j) == sorted(routes)
+        print(j)
+        #assert sorted(j) == sorted(routes)
+        for r in routes:
+            assert r in j
 
         # Patch del
         for route in routes:
@@ -1276,7 +1280,9 @@ class TestRestApiPositive:
         assert r.status_code == 200
         j = json.loads(r.text)
         routes = []
-        assert sorted(j) == sorted(routes)
+        #assert sorted(j) == sorted(routes)
+        for r in routes:
+            assert r in j
 
         # Test modify
         routes.append({'cmd':'add',
@@ -1302,7 +1308,9 @@ class TestRestApiPositive:
         assert r.status_code == 200
 
         j = json.loads(r.text)
-        assert sorted(j) == sorted(routes)
+        #assert sorted(j) == sorted(routes)
+        for r in routes:
+            assert r in j
 
     def test_local_subnet_route_addition(self, setup_restapi_client):
         db, _, _, restapi_client = setup_restapi_client

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -1769,6 +1769,24 @@ class TestRestApiNegative():
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 400
 
+    def test_patch_update_static_routes(self, setup_restapi_client):
+        _, _, _, restapi_client = setup_restapi_client
+        restapi_client.post_generic_vlan_and_deps()
+        route = {
+                    'cmd':'add',
+                    'ip_prefix':'10.2.1.0/24',
+                    'nexthop':'192.168.2.1'
+                }
+        route['persistent'] = 'bool'
+        route['cmd'] = 'add'
+        r = restapi_client.patch_config_vrf_vrf_id_routes("vnet-guid-1", [route])
+        assert r.status_code == 500
+        r = restapi_client.patch_config_vrf_vrf_id_routes("default", [route])
+        assert r.status_code == 400        
+        j = json.loads(r.text)
+        assert j['error']['fields'] == ['persistent']
+        assert j['error']['details'] == "must be either true or false"
+
     # Static Route Expiry
     def test_static_route_expiry_post(self, setup_restapi_client):
         _, _, _, restapi_client = setup_restapi_client

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -1234,9 +1234,11 @@ class TestRestApiPositive:
                             'persistent': 'true'})
 
         routes.append({'cmd':'add',
-                            'ip_prefix':'60.1.2.0/24',
-                            'ifname':'Ethernet8',
-                            'persistent': 'true'})
+                            'ip_prefix':'fd30:fc14:8a92:b4e3::/64',
+                            'nexthop':'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404',
+                            'nexthop_monitor':'cac4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,a803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404',
+                            'weight':'10,20',
+                            'profile':'profile2'})
 
         routes.append({'cmd':'add',
                             'ip_prefix':'70.1.2.0/24',

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -1618,7 +1618,8 @@ class TestRestApiNegative():
                             'ip_prefix':'10.2.'+str(i)+'.0/24',
                             'nexthop':'192.168.2.'+str(i),
                             'vnid': 1 + i%5,
-                            'mac_address':'00:08:aa:bb:cd:'+hex(15+i)[2:]})
+                            'mac_address':'00:08:aa:bb:cd:'+hex(15+i)[2:],
+                            'persistent': 'false'})
 
         # Patch
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", routes)

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -1095,7 +1095,7 @@ class TestRestApiPositive:
                             'ifname':'Ethernet0,Ethernet4,Ethernet8'})
 
         routes.append({'cmd':'add',
-                            'ip_prefix':'50.1.2.0/24',
+                            'ip_prefix':'fd30:fc14:8a92:b4d3::/64',
                             'ifname':'Ethernet0,Ethernet4'})
 
         routes.append({'cmd':'add',
@@ -1229,7 +1229,7 @@ class TestRestApiPositive:
                             'persistent': 'true'})
 
         routes.append({'cmd':'add',
-                            'ip_prefix':'50.1.2.0/24',
+                            'ip_prefix':'fd30:fc14:8a92:b4e4::/64',
                             'ifname':'Ethernet0,Ethernet4',
                             'persistent': 'true'})
 
@@ -1263,9 +1263,7 @@ class TestRestApiPositive:
         assert r.status_code == 200
         j = json.loads(r.text)
         print(j)
-        #assert sorted(j) == sorted(routes)
-        for r in routes:
-            assert r in j
+        assert sorted(j) == sorted(routes)
 
         # Patch del
         for route in routes:
@@ -1280,9 +1278,7 @@ class TestRestApiPositive:
         assert r.status_code == 200
         j = json.loads(r.text)
         routes = []
-        #assert sorted(j) == sorted(routes)
-        for r in routes:
-            assert r in j
+        assert sorted(j) == sorted(routes)
 
         # Test modify
         routes.append({'cmd':'add',
@@ -1308,9 +1304,7 @@ class TestRestApiPositive:
         assert r.status_code == 200
 
         j = json.loads(r.text)
-        #assert sorted(j) == sorted(routes)
-        for r in routes:
-            assert r in j
+        assert sorted(j) == sorted(routes)
 
     def test_local_subnet_route_addition(self, setup_restapi_client):
         db, _, _, restapi_client = setup_restapi_client


### PR DESCRIPTION
This PR has two parts:
  1. Support for two new APIs:
      GET
      Path: `/v1/config/vrf/static_route/route_expiry`
      Return value: `{"time": <time in seconds>}`
      
      POST
      Path: `/v1/config/vrf/static_route/route_expiry`
      Param: `{"time": <time in seconds>}`


 2. Modification to VRF route PATCH API:
     - check if static route is persistent or not and add it to the right DB