### PR TITLE
[Static Route Expiry] Update API contract

### DIFF
--- a/sonic_api.yaml
+++ b/sonic_api.yaml
@@ -1666,6 +1666,57 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 #----------------------------------------------
+# Static Route Expiry
+#----------------------------------------------
+  '/config/vrf/static_route/route_expiry':
+    get:
+      operationId: ConfigVrfStaticRouteExpiryGet
+      summary: API for caller to get the custom static route expiry time
+      description: Returns a JSON response with the expiration time for all non-persistent static routes
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/StaticRouteExpiryTime'
+        '401':
+          description: Invalid authentication credentials
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/Error'
+        '503':
+          description: Maintanence mode
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: API for caller to set the custom static route expiry time
+      operationId: ConfigVrfStaticRouteExpiryPost
+      description: Sets the custom expiration time for all non-persistent static routes
+      parameters:
+        - name: strtexptime
+          in: body
+          required: true
+          description: Static Route Expiry Time
+          schema:
+            $ref: '#/definitions/StaticRouteExpiryTime'
+      responses:
+        '200':
+          description: OK
+        '401':
+          description: Invalid authentication credentials
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/Error'
+        '503':
+          description: Maintanence mode
+          schema:
+            $ref: '#/definitions/Error'
+#----------------------------------------------
 # QinQ subinterface object
 #----------------------------------------------
   '/config/subinterface/qinq/{if_name}/{outer_tag}/{inner_tag}':
@@ -2862,3 +2913,11 @@ definitions:
       community_id:
         type: string
         description: Community ID for the BGP profile
+  StaticRouteExpiryTime:
+    type: object
+    required: 
+      - time
+    properties:
+      time:
+        type: int
+        description: expiration time in seconds for non-persistent static routes


### PR DESCRIPTION
Update API contract to support GET and POST of custom expiration time for non-persistent static routes
GET
Path: `/v1/config/vrf/static_route/route_expiry`
Return value: `{"time": <time in seconds>}`

POST
Path: `/v1/config/vrf/static_route/route_expiry`
Param: `{"time": <time in seconds>}`