### PR TITLE
Install libyang to azure pipeline

### DIFF
--- a/Dockerfile.common.prod
+++ b/Dockerfile.common.prod
@@ -17,6 +17,7 @@ RUN dpkg -i /debs/libhiredis0.13_0.13.3-2_amd64.deb \
  && dpkg -i /debs/libnl-3-200_3.2.27-1_amd64.deb \
  && dpkg -i /debs/libnl-genl-3-200_3.2.27-1_amd64.deb \
  && dpkg -i /debs/libnl-route-3-200_3.2.27-1_amd64.deb \
+ && dpkg -i /debs/libyang_1.0.73_amd64.deb \
  && dpkg -i /debs/libswsscommon_1.0.0_amd64.deb \
  && dpkg -i /debs/libswsscommon-dev_1.0.0_amd64.deb \
  && dpkg -i /debs/sonic-rest-api_1.0.1_amd64.deb \

--- a/copy.sh
+++ b/copy.sh
@@ -8,5 +8,6 @@ wget -O debs/libnl-genl-3-200_3.5.0-1_amd64.deb  'https://sonic-build.azurewebsi
 wget -O debs/libnl-route-3-200_3.5.0-1_amd64.deb  'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libnl-route-3-200_3.5.0-1_amd64.deb'
 wget -O debs/libnl-nf-3-200_3.5.0-1_amd64.deb  'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libnl-nf-3-200_3.5.0-1_amd64.deb'
 wget -O debs/libthrift-0.11.0_0.11.0-4_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libthrift-0.11.0_0.11.0-4_amd64.deb'
+wget -O debs/libyang_1.0.73_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibyang_1.0.73_amd64.deb'
 wget -O debs/libswsscommon_1.0.0_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibswsscommon_1.0.0_amd64.deb'
 wget -O debs/libswsscommon-dev_1.0.0_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibswsscommon-dev_1.0.0_amd64.deb'

--- a/dependencies.conf
+++ b/dependencies.conf
@@ -11,6 +11,7 @@
                         "libnl-genl-3-200_3.5.0-1",
                         "libnl-route-3-200_3.5.0-1",
                         "libnl-nf-3-200_3.5.0-1",
+                        "libyang_1.0.73",
                         "libswsscommon_1.0.0",
                         "libswsscommon-dev_1.0.0"
                     ]


### PR DESCRIPTION
#### Why I did it
sonic-swss-common lib will add dependency to libyang soon, so need install libyang lib to prevent build and UT break.

#### How I did it
Modify azure pipeline to install libyang in azure pipeline steps.

#### How to verify it
Pass all UT.

#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog
Modify azure pipeline to install libyang in azure pipeline steps.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

