### PR TITLE
Updates to route PATCH API

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1290,6 +1290,7 @@ func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
                 if r.IfName == "" {
                     if cur_route["endpoint"] != r.NextHop ||
                         cur_route["endpoint_monitor"] != r.NextHopMonitor ||
+                        cur_route["primary"] != r.Primary ||
                         cur_route["mac_address"] != r.MACAddress ||
                         cur_route["vni"] != strconv.Itoa(r.Vnid) ||
                         cur_route["weight"] != r.Weight ||
@@ -1390,6 +1391,23 @@ func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
                 }
                 if r.NextHopMonitor != "" {
                     route_map["endpoint_monitor"] = r.NextHopMonitor
+                }
+                if r.Primary != "" {
+                    success := true
+                    nexthops := ExtractIPsFromString(r.NextHop)
+                    primaries := ExtractIPsFromString(r.Primary)
+                    for _, primary := range primaries {
+                        if !IsPresentInSlice(nexthops, primary) {
+                            r.Error_msg = primary+" not present in nexthop list"
+                            failed = append(failed, r)
+                            success = false
+                            break                            
+                        }
+                    }
+                    if success == false {
+                        continue
+                    }
+                    route_map["primary"] = r.Primary                    
                 }
                 if r.Weight != "" {
                     route_map["weight"] = r.Weight

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -222,7 +222,7 @@ func (m *RouteModel) UnmarshalJSON(data []byte) (err error) {
     } 
 
     if *required.Cmd != "add" && *required.Cmd != "delete" && *required.Cmd != "append" && *required.Cmd != "remove" {
-        err = &InvalidFormatError{Field: "cmd", Message: "Must be add/delete/update"}
+        err = &InvalidFormatError{Field: "cmd", Message: "Must be add/delete/append/delete"}
         return
     }
 

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -221,8 +221,8 @@ func (m *RouteModel) UnmarshalJSON(data []byte) (err error) {
         }
     } 
 
-    if *required.Cmd != "add" && *required.Cmd != "delete" {
-        err = &InvalidFormatError{Field: "cmd", Message: "Must be add/delete"}
+    if *required.Cmd != "add" && *required.Cmd != "delete" && *required.Cmd != "append" && *required.Cmd != "remove" {
+        err = &InvalidFormatError{Field: "cmd", Message: "Must be add/delete/update"}
         return
     }
 
@@ -247,7 +247,7 @@ func (m *RouteModel) UnmarshalJSON(data []byte) (err error) {
         }
         nexthops := strings.Split(m.NextHop, ",")
         nexthop_mon := strings.Split(*required.NextHopMonitor, ",")
-        if len(nexthops) != len(nexthop_mon) {
+        if *required.Cmd == "add" && len(nexthops) != len(nexthop_mon) {
             err = &InvalidFormatError{Field: "nexthop_monitor", Message: "there must be equal number of nexthop(s) and nexthop_monitor(s)"}
             return            
         }

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -33,6 +33,7 @@ type RouteModel struct {
     NextHopType    string `json:"nexthop_type,omitempty"`
     NextHop        string `json:"nexthop"`
     NextHopMonitor string `json:"nexthop_monitor,omitempty"`
+    Primary        string `json:"primary,omitempty"`
     MACAddress     string `json:"mac_address,omitempty"`
     Vnid           int    `json:"vnid,omitempty"`
     Weight         string `json:"weight,omitempty"`
@@ -194,6 +195,7 @@ func (m *RouteModel) UnmarshalJSON(data []byte) (err error) {
         NextHopType    *string `json:"nexthop_type"`
         NextHop        *string `json:"nexthop"`
         NextHopMonitor *string `json:"nexthop_monitor"`
+        Primary        *string `json:"primary"`
         MACAddress     *string `json:"mac_address"`
         Vnid           int     `json:"vnid"`
         Weight         *string `json:"weight"`
@@ -252,6 +254,14 @@ func (m *RouteModel) UnmarshalJSON(data []byte) (err error) {
             return            
         }
         m.NextHopMonitor = *required.NextHopMonitor
+    }
+
+    if required.Primary != nil {
+        if !strings.Contains(*required.Primary, ",") && !IsValidIPBoth(*required.Primary) {
+            err = &InvalidFormatError{Field: "primary", Message: "Invalid IP address"}
+            return
+        }
+        m.Primary = *required.Primary
     }
 
     if required.IfName == nil && required.MACAddress != nil {

--- a/go-server-server/go/persistent.go
+++ b/go-server-server/go/persistent.go
@@ -315,7 +315,11 @@ func SwssGetVrouterRoutes(vnet_id_str string, vnidMatch int, ipFilter string) (r
         if nexthop_monitor, ok := kvp["endpoint_monitor"]; ok {
             routeModel.NextHopMonitor = nexthop_monitor
         }
-        
+
+        if primary, ok := kvp["primary"]; ok {
+            routeModel.Primary = primary
+        }        
+
         if weight, ok := kvp["weight"]; ok {
             routeModel.Weight = weight
         }
@@ -342,7 +346,11 @@ func SwssGetVrouterRoutes(vnet_id_str string, vnidMatch int, ipFilter string) (r
         if nexthop_monitor, ok := kvp["endpoint_monitor"]; ok {
             routeModel.NextHopMonitor = nexthop_monitor
         }
-        
+
+        if primary, ok := kvp["primary"]; ok {
+            routeModel.Primary = primary
+        }        
+
         if weight, ok := kvp["weight"]; ok {
             routeModel.Weight = weight
         }

--- a/go-server-server/go/util.go
+++ b/go-server-server/go/util.go
@@ -120,6 +120,23 @@ func ReadJSONBody(w http.ResponseWriter, r *http.Request, attr interface{}) erro
     return nil
 }
 
+func ExtractIPsFromString(str_t string) []string {
+    var IPs []string 
+    if strings.Contains(str_t, ",") {
+        ips := strings.Split(str_t, ",")
+        for _, ip := range ips {
+            if net.ParseIP(ip) != nil {
+                IPs = append(IPs, ip)
+            }
+        }
+    } else {
+        if net.ParseIP(str_t) != nil {
+            IPs = append(IPs, str_t)
+        }        
+    }
+    return IPs
+}
+
 func IsPresentInSlice(slice_t []string, item string) bool {
     for _, str_t := range slice_t {
         if str_t == item {

--- a/go-server-server/go/util.go
+++ b/go-server-server/go/util.go
@@ -120,6 +120,29 @@ func ReadJSONBody(w http.ResponseWriter, r *http.Request, attr interface{}) erro
     return nil
 }
 
+func IsPresentInSlice(slice_t []string, item string) bool {
+    for _, str_t := range slice_t {
+        if str_t == item {
+            return true
+        }
+    }
+    return false
+}
+
+func RemoveFromSlice(slice_t []string, item string) (bool, []string) {
+    index := -1
+    for idx, str_t := range slice_t {
+        if str_t == item {
+            index = idx
+            break
+        }
+    }
+    if index == -1 {
+        return false, nil
+    }
+    return true, append(slice_t[:index], slice_t[index+1:]...)
+}
+
 func IsValidIP(ipstr string) bool {
     ip := net.ParseIP(ipstr)
     return (ip != nil) && (ip.To4() != nil)

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -1050,7 +1050,6 @@ class TestRestApiPositive:
         j = json.loads(r.text)
         assert sorted(j) == sorted(routes)  
 
-
         # Update Nexthops and Nexthop monitors
         route['cmd'] = "append"
         route['nexthop'] = 'b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
@@ -1058,7 +1057,7 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        route['nexthop'] = 'bbc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53c6:d1e5:6db5:82cc:c35a:c1d8:4404,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
         assert route_table == {b'endpoint' : route['nexthop'],
                                 b'endpoint_monitor': route['nexthop_monitor'],
                                 b'vni': str(route['vnid']), 
@@ -1075,12 +1074,12 @@ class TestRestApiPositive:
         assert sorted(j) == sorted(routes)
 
         route['cmd'] = "remove"
-        route['nexthop'] = 'b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        route['nexthop'] = 'b803:53c6:d1e5:6db5:82cc:c35a:c1d8:4404'
         route['nexthop_monitor'] = 'b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        route['nexthop'] = 'bbc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
         route['nexthop_monitor'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
         assert route_table == {b'endpoint' : route['nexthop'],
                                 b'endpoint_monitor': route['nexthop_monitor'],

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -1050,9 +1050,7 @@ class TestRestApiPositive:
         j = json.loads(r.text)
         assert sorted(j) == sorted(routes)  
 
-        del route['vnid']
-        del route['mac_address']
-        del route['profile']
+
         # Update Nexthops and Nexthop monitors
         route['cmd'] = "append"
         route['nexthop'] = 'b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -753,6 +753,52 @@ class TestRestApiPositive:
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         assert route_table == {b'endpoint' : route['nexthop']}
 
+        # Update Nexthops and Nexthop monitors
+        route['cmd'] = "append"
+        route['nexthop'] = '200.3.152.33'
+        route['nexthop_monitor'] = '100.3.152.32,200.3.152.32,200.3.152.33'
+        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
+        assert r.status_code == 204
+        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
+        route['nexthop'] = '100.3.152.32,200.3.152.32,200.3.152.33'
+        assert route_table == {b'endpoint' : route['nexthop'],
+                                b'endpoint_monitor': route['nexthop_monitor'],
+                                b'vni': str(route['vnid']), 
+                                b'mac_address' : route['mac_address'],
+                                b'profile': route['profile']
+                                }
+        del route['cmd']
+        routes = list()
+        routes.append(route)
+        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
+        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
+        assert r.status_code == 200
+        j = json.loads(r.text)
+        assert sorted(j) == sorted(routes)
+
+        route['cmd'] = "remove"
+        route['nexthop'] = '200.3.152.32'
+        route['nexthop_monitor'] = '200.3.152.32'
+        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
+        assert r.status_code == 204
+        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
+        route['nexthop'] = '100.3.152.32,200.3.152.33'
+        route['nexthop_monitor'] = '100.3.152.32,200.3.152.33'
+        assert route_table == {b'endpoint' : route['nexthop'],
+                                b'endpoint_monitor': route['nexthop_monitor'],
+                                b'vni': str(route['vnid']), 
+                                b'mac_address' : route['mac_address'],
+                                b'profile': route['profile']
+                                }
+        del route['cmd']
+        routes = list()
+        routes.append(route)
+        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
+        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
+        assert r.status_code == 200
+        j = json.loads(r.text)
+        assert sorted(j) == sorted(routes)
+
         # Delete route
         route['cmd'] = 'delete'
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
@@ -776,7 +822,7 @@ class TestRestApiPositive:
         r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
         assert r.status_code == 200
         j = json.loads(r.text)
-        assert sorted(j) == sorted(routes)       
+        assert sorted(j) == sorted(routes)   
 
         # Mac address Optional arg
         del route['vnid']
@@ -860,7 +906,8 @@ class TestRestApiPositive:
         r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
         assert r.status_code == 200
         j = json.loads(r.text)
-        assert sorted(j) == sorted(routes)     
+        assert sorted(j) == sorted(routes)
+
 
     def test_patch_update_v6_routes_with_optional_args(self, setup_restapi_client):
         db, _, _, restapi_client = setup_restapi_client
@@ -892,6 +939,52 @@ class TestRestApiPositive:
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         assert route_table == {b'endpoint' : route['nexthop']}
+
+        # Update Nexthops and Nexthop monitors
+        route['cmd'] = "append"
+        route['nexthop'] = 'b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        route['nexthop_monitor'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
+        assert r.status_code == 204
+        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
+        route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        assert route_table == {b'endpoint' : route['nexthop'],
+                                b'endpoint_monitor': route['nexthop_monitor'],
+                                b'vni': str(route['vnid']), 
+                                b'mac_address' : route['mac_address'],
+                                b'profile': route['profile']
+                                }
+        del route['cmd']
+        routes = list()
+        routes.append(route)
+        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
+        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
+        assert r.status_code == 200
+        j = json.loads(r.text)
+        assert sorted(j) == sorted(routes)
+
+        route['cmd'] = "remove"
+        route['nexthop'] = 'b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        route['nexthop_monitor'] = 'b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
+        assert r.status_code == 204
+        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
+        route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        route['nexthop_monitor'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        assert route_table == {b'endpoint' : route['nexthop'],
+                                b'endpoint_monitor': route['nexthop_monitor'],
+                                b'vni': str(route['vnid']), 
+                                b'mac_address' : route['mac_address'],
+                                b'profile': route['profile']
+                                }
+        del route['cmd']
+        routes = list()
+        routes.append(route)
+        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
+        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
+        assert r.status_code == 200
+        j = json.loads(r.text)
+        assert sorted(j) == sorted(routes)
 
         # Delete route
         route['cmd'] = 'delete'

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -862,9 +862,7 @@ class TestRestApiPositive:
         j = json.loads(r.text)
         assert sorted(j) == sorted(routes)
 
-        del route['vnid']
-        del route['mac_address']
-        del route['profile']
+
         # Update Nexthops and Nexthop monitors
         route['cmd'] = "append"
         route['nexthop'] = '200.3.152.33'
@@ -874,7 +872,10 @@ class TestRestApiPositive:
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         route['nexthop'] = '100.3.152.32,200.3.152.32,200.3.152.33'
         assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor']
+                                b'endpoint_monitor': route['nexthop_monitor'],
+                                b'vni': str(route['vnid']), 
+                                b'mac_address' : route['mac_address'],
+                                b'profile': route['profile']                                
                                 }
         del route['cmd']
         routes = list()
@@ -894,7 +895,10 @@ class TestRestApiPositive:
         route['nexthop'] = '100.3.152.32,200.3.152.33'
         route['nexthop_monitor'] = '100.3.152.32,200.3.152.33'
         assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor']
+                                b'endpoint_monitor': route['nexthop_monitor'],
+                                b'vni': str(route['vnid']), 
+                                b'mac_address' : route['mac_address'],
+                                b'profile': route['profile']
                                 }
         del route['cmd']
         routes = list()
@@ -1058,7 +1062,10 @@ class TestRestApiPositive:
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
         assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor']
+                                b'endpoint_monitor': route['nexthop_monitor'],
+                                b'vni': str(route['vnid']), 
+                                b'mac_address' : route['mac_address'],
+                                b'profile': route['profile']
                                 }
         del route['cmd']
         routes = list()
@@ -1078,7 +1085,10 @@ class TestRestApiPositive:
         route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
         route['nexthop_monitor'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
         assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor']
+                                b'endpoint_monitor': route['nexthop_monitor'],
+                                b'vni': str(route['vnid']), 
+                                b'mac_address' : route['mac_address'],
+                                b'profile': route['profile']
                                 }
         del route['cmd']
         routes = list()

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -2123,9 +2123,15 @@ class TestRestApiNegative():
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 400
         j = json.loads(r.text)
-        print(j)
         assert j['error']['fields'] == ['cmd']
         assert j['error']['details'] == "Must be add/delete/append/delete"
+
+        route['cmd'] = 'append'
+        route['nexthop'] = '192.168.2.1'
+        route['nexthop_monitor'] = '192.168.2.7'
+        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
+        assert r.status_code == 204
+        del route['nexthop_monitor']
 
         route['cmd'] = 'append'
         route['nexthop'] = '192.168.2.2'

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -762,10 +762,7 @@ class TestRestApiPositive:
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         route['nexthop'] = '100.3.152.32,200.3.152.32,200.3.152.33'
         assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor'],
-                                b'vni': str(route['vnid']), 
-                                b'mac_address' : route['mac_address'],
-                                b'profile': route['profile']
+                                b'endpoint_monitor': route['nexthop_monitor']
                                 }
         del route['cmd']
         routes = list()
@@ -785,10 +782,7 @@ class TestRestApiPositive:
         route['nexthop'] = '100.3.152.32,200.3.152.33'
         route['nexthop_monitor'] = '100.3.152.32,200.3.152.33'
         assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor'],
-                                b'vni': str(route['vnid']), 
-                                b'mac_address' : route['mac_address'],
-                                b'profile': route['profile']
+                                b'endpoint_monitor': route['nexthop_monitor']
                                 }
         del route['cmd']
         routes = list()
@@ -949,10 +943,7 @@ class TestRestApiPositive:
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
         assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor'],
-                                b'vni': str(route['vnid']), 
-                                b'mac_address' : route['mac_address'],
-                                b'profile': route['profile']
+                                b'endpoint_monitor': route['nexthop_monitor']
                                 }
         del route['cmd']
         routes = list()
@@ -972,10 +963,7 @@ class TestRestApiPositive:
         route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
         route['nexthop_monitor'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
         assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor'],
-                                b'vni': str(route['vnid']), 
-                                b'mac_address' : route['mac_address'],
-                                b'profile': route['profile']
+                                b'endpoint_monitor': route['nexthop_monitor']
                                 }
         del route['cmd']
         routes = list()

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -753,46 +753,6 @@ class TestRestApiPositive:
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         assert route_table == {b'endpoint' : route['nexthop']}
 
-        # Update Nexthops and Nexthop monitors
-        route['cmd'] = "append"
-        route['nexthop'] = '200.3.152.33'
-        route['nexthop_monitor'] = '100.3.152.32,200.3.152.32,200.3.152.33'
-        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
-        assert r.status_code == 204
-        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        route['nexthop'] = '100.3.152.32,200.3.152.32,200.3.152.33'
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor']
-                                }
-        del route['cmd']
-        routes = list()
-        routes.append(route)
-        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
-        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
-        assert r.status_code == 200
-        j = json.loads(r.text)
-        assert sorted(j) == sorted(routes)
-
-        route['cmd'] = "remove"
-        route['nexthop'] = '200.3.152.32'
-        route['nexthop_monitor'] = '200.3.152.32'
-        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
-        assert r.status_code == 204
-        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        route['nexthop'] = '100.3.152.32,200.3.152.33'
-        route['nexthop_monitor'] = '100.3.152.32,200.3.152.33'
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor']
-                                }
-        del route['cmd']
-        routes = list()
-        routes.append(route)
-        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
-        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
-        assert r.status_code == 200
-        j = json.loads(r.text)
-        assert sorted(j) == sorted(routes)
-
         # Delete route
         route['cmd'] = 'delete'
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
@@ -902,6 +862,49 @@ class TestRestApiPositive:
         j = json.loads(r.text)
         assert sorted(j) == sorted(routes)
 
+        del route['vnid']
+        del route['mac_address']
+        del route['profile']
+        # Update Nexthops and Nexthop monitors
+        route['cmd'] = "append"
+        route['nexthop'] = '200.3.152.33'
+        route['nexthop_monitor'] = '100.3.152.32,200.3.152.32,200.3.152.33'
+        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
+        assert r.status_code == 204
+        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
+        route['nexthop'] = '100.3.152.32,200.3.152.32,200.3.152.33'
+        assert route_table == {b'endpoint' : route['nexthop'],
+                                b'endpoint_monitor': route['nexthop_monitor']
+                                }
+        del route['cmd']
+        routes = list()
+        routes.append(route)
+        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
+        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
+        assert r.status_code == 200
+        j = json.loads(r.text)
+        assert sorted(j) == sorted(routes)
+
+        route['cmd'] = "remove"
+        route['nexthop'] = '200.3.152.32'
+        route['nexthop_monitor'] = '200.3.152.32'
+        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
+        assert r.status_code == 204
+        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
+        route['nexthop'] = '100.3.152.32,200.3.152.33'
+        route['nexthop_monitor'] = '100.3.152.32,200.3.152.33'
+        assert route_table == {b'endpoint' : route['nexthop'],
+                                b'endpoint_monitor': route['nexthop_monitor']
+                                }
+        del route['cmd']
+        routes = list()
+        routes.append(route)
+        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
+        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
+        assert r.status_code == 200
+        j = json.loads(r.text)
+        assert sorted(j) == sorted(routes)
+
 
     def test_patch_update_v6_routes_with_optional_args(self, setup_restapi_client):
         db, _, _, restapi_client = setup_restapi_client
@@ -933,46 +936,6 @@ class TestRestApiPositive:
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         assert route_table == {b'endpoint' : route['nexthop']}
-
-        # Update Nexthops and Nexthop monitors
-        route['cmd'] = "append"
-        route['nexthop'] = 'b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
-        route['nexthop_monitor'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
-        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
-        assert r.status_code == 204
-        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor']
-                                }
-        del route['cmd']
-        routes = list()
-        routes.append(route)
-        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
-        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
-        assert r.status_code == 200
-        j = json.loads(r.text)
-        assert sorted(j) == sorted(routes)
-
-        route['cmd'] = "remove"
-        route['nexthop'] = 'b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
-        route['nexthop_monitor'] = 'b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
-        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
-        assert r.status_code == 204
-        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
-        route['nexthop_monitor'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor']
-                                }
-        del route['cmd']
-        routes = list()
-        routes.append(route)
-        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
-        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
-        assert r.status_code == 200
-        j = json.loads(r.text)
-        assert sorted(j) == sorted(routes)
 
         # Delete route
         route['cmd'] = 'delete'
@@ -1082,6 +1045,49 @@ class TestRestApiPositive:
         assert r.status_code == 200
         j = json.loads(r.text)
         assert sorted(j) == sorted(routes)  
+
+        del route['vnid']
+        del route['mac_address']
+        del route['profile']
+        # Update Nexthops and Nexthop monitors
+        route['cmd'] = "append"
+        route['nexthop'] = 'b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        route['nexthop_monitor'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
+        assert r.status_code == 204
+        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
+        route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        assert route_table == {b'endpoint' : route['nexthop'],
+                                b'endpoint_monitor': route['nexthop_monitor']
+                                }
+        del route['cmd']
+        routes = list()
+        routes.append(route)
+        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
+        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
+        assert r.status_code == 200
+        j = json.loads(r.text)
+        assert sorted(j) == sorted(routes)
+
+        route['cmd'] = "remove"
+        route['nexthop'] = 'b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        route['nexthop_monitor'] = 'b803:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
+        assert r.status_code == 204
+        route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
+        route['nexthop'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        route['nexthop_monitor'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
+        assert route_table == {b'endpoint' : route['nexthop'],
+                                b'endpoint_monitor': route['nexthop_monitor']
+                                }
+        del route['cmd']
+        routes = list()
+        routes.append(route)
+        routes.append({'nexthop': '', 'ip_prefix': '10.1.1.0/24', 'ifname': 'Vlan2'})
+        r = restapi_client.get_config_vrouter_vrf_id_routes("vnet-guid-1")
+        assert r.status_code == 200
+        j = json.loads(r.text)
+        assert sorted(j) == sorted(routes)
 
     def test_patch_routes_drop_bm_routes_tunnel(self, setup_restapi_client):
         _, _, _, restapi_client = setup_restapi_client


### PR DESCRIPTION
1. Support appending 1 or more `nexthop` and `nexthop_monitor` to existing route entry
2. Support removing 1 or more `nexthop` and `nexthop_monitor` from existing route entry
3. Support for setting `primary` nexthop