### PR TITLE
Add API support for adv prefix and custom monitoring

### DIFF
--- a/azurepipeline.yml
+++ b/azurepipeline.yml
@@ -39,7 +39,7 @@ jobs:
         pip install redis
         pip install -U pytest
         cd test
-        pytest -v
+        pytest -vv
         docker exec rest-api cat /tmp/rest-api.err.log
         docker exec rest-api ps aux
         sleep 600

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1080,6 +1080,9 @@ func ConfigVrouterVrfIdPost(w http.ResponseWriter, r *http.Request) {
         vnetParams["advertise_prefix"] = attr.AdvPrefix
         CacheSetPrefixAdv(vnet_id_str, attr.AdvPrefix)
     }
+    if attr.OverlayDmac != "" {
+        vnetParams["overlay_dmac"] = attr.OverlayDmac
+    }
     pt.Set(vnet_id_str, vnetParams, "SET", "")        
 
     w.WriteHeader(http.StatusNoContent)
@@ -1291,6 +1294,7 @@ func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
                     if cur_route["endpoint"] != r.NextHop ||
                         cur_route["endpoint_monitor"] != r.NextHopMonitor ||
                         cur_route["primary"] != r.Primary ||
+                        cur_route["adv_prefix"] != r.AdvPrefix ||
                         cur_route["mac_address"] != r.MACAddress ||
                         cur_route["vni"] != strconv.Itoa(r.Vnid) ||
                         cur_route["weight"] != r.Weight ||
@@ -1414,6 +1418,12 @@ func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
                 }
                 if r.Profile != "" {
                     route_map["profile"] = r.Profile
+                }
+                if r.AdvPrefix != "" {
+                    route_map["adv_prefix"] = r.AdvPrefix
+                }
+                if r.Monitoring != "" {
+                    route_map["monitoring"] = r.Monitoring
                 }
                 pt.Set(generateDBTableKey(db.separator,vnet_id_str, r.IPPrefix), route_map, "SET", "")
             } else {
@@ -1654,6 +1664,7 @@ func ConfigVrfVrfIdRoutesGet(w http.ResponseWriter, r *http.Request) {
         if profile, ok := kvp["profile"]; ok {
             routeModel.Profile = profile
         }
+
         routes = append(routes, routeModel)
     }
 

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -34,6 +34,8 @@ type RouteModel struct {
     NextHop        string `json:"nexthop"`
     NextHopMonitor string `json:"nexthop_monitor,omitempty"`
     Primary        string `json:"primary,omitempty"`
+    AdvPrefix      string `json:"adv_prefix,omitempty"`
+    Monitoring     string `json:"monitoring,omitempty"`
     MACAddress     string `json:"mac_address,omitempty"`
     Vnid           int    `json:"vnid,omitempty"`
     Weight         string `json:"weight,omitempty"`
@@ -137,6 +139,7 @@ type TunnelDecapReturnModel struct {
 type VnetModel struct {
     Vnid        int     `json:"vnid"`
     AdvPrefix   string  `json:"advertise_prefix,omitempty"`
+    OverlayDmac string  `json:"overlay_dmac,omitempty"`
 }
 
 type VnetReturnModel struct {
@@ -196,6 +199,8 @@ func (m *RouteModel) UnmarshalJSON(data []byte) (err error) {
         NextHop        *string `json:"nexthop"`
         NextHopMonitor *string `json:"nexthop_monitor"`
         Primary        *string `json:"primary"`
+        AdvPrefix      *string `json:"adv_prefix"`
+        Monitoring     *string `json:"monitoring"`
         MACAddress     *string `json:"mac_address"`
         Vnid           int     `json:"vnid"`
         Weight         *string `json:"weight"`
@@ -264,6 +269,15 @@ func (m *RouteModel) UnmarshalJSON(data []byte) (err error) {
         m.Primary = *required.Primary
     }
 
+    if required.AdvPrefix != nil {
+        _, _, err = ParseIPBothPrefix(*required.AdvPrefix)
+        if err != nil {
+            err = &InvalidFormatError{Field: "adv_prefix", Message: "Invalid advertisement prefix"}
+            return
+        }
+        m.AdvPrefix = *required.AdvPrefix
+    }
+
     if required.IfName == nil && required.MACAddress != nil {
         _, err = net.ParseMAC(*required.MACAddress)
 
@@ -296,6 +310,9 @@ func (m *RouteModel) UnmarshalJSON(data []byte) (err error) {
     }
     if required.Profile != nil {
         m.Profile = *required.Profile
+    }
+    if required.Monitoring != nil {
+        m.Monitoring = *required.Monitoring
     }
     return
 }
@@ -373,6 +390,7 @@ func (m *VnetModel) UnmarshalJSON(data []byte) (err error) {
     required := struct {
         Vnid        *int    `json:"vnid"`
         AdvPrefix   *string `json:"advertise_prefix"`
+        OverlayDmac *string `json:"overlay_dmac"`
     }{}
 
     err = json.Unmarshal(data, &required)
@@ -398,6 +416,15 @@ func (m *VnetModel) UnmarshalJSON(data []byte) (err error) {
         } else {
             err = &InvalidFormatError{Field: "advertise_prefix", Message: "advertise_prefix must be either true or false"}
         }
+    }
+
+    if required.OverlayDmac != nil {
+        _, err = net.ParseMAC(*required.OverlayDmac)
+        if err != nil {
+            err = &InvalidFormatError{Field: "mac_address", Message: "Invalid MAC address"}
+            return
+        }
+        m.OverlayDmac = *required.OverlayDmac
     }
 
     return

--- a/go-server-server/go/persistent.go
+++ b/go-server-server/go/persistent.go
@@ -328,6 +328,14 @@ func SwssGetVrouterRoutes(vnet_id_str string, vnidMatch int, ipFilter string) (r
             routeModel.Profile = profile
         }
 
+        if adv_prefix, ok := kvp["adv_prefix"]; ok {
+            routeModel.AdvPrefix = adv_prefix
+        }
+
+        if monitoring, ok := kvp["monitoring"]; ok {
+            routeModel.Monitoring = monitoring
+        }
+
         routes = append(routes, routeModel)
     }
 


### PR DESCRIPTION
Support the following API attributes:

1. adv_prefix and monitoring
```
curl --request PATCH -H "Content-Type:application/json" -d '
[{"cmd":"add", "ip_prefix":"10.0.1.10/32", "nexthop":"100.3.152.32,100.3.153.32","nexthop_monitor":"200.3.152.32,200.3.153.32", "primary":"100.3.152.32", "monitoring":"custom", "adv_prefix":"10.0.1.0/24"}]'
```
2. overlay_dmac
```
curl --request POST -H "Content-Type:application/json" -d 
'{"vnid":8000, "advertise_prefix":"true", "overlay_dmac":"22:33:44:55:66:77"}
```