### PR TITLE
[AdvPfx] Fix mask len for ipv6

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1441,8 +1441,8 @@ func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
                             continue
                         }
                     } else {
-                        if prefix_len < 64 {
-                            r.Error_msg = "Adv Prefix length lesser than 64 is not supported"
+                        if prefix_len < 60 {
+                            r.Error_msg = "Adv Prefix length lesser than 60 is not supported"
                             failed = append(failed, r)
                             continue
                         }

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -2256,7 +2256,7 @@ class TestRestApiNegative():
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 207
         j = json.loads(r.text)
-        assert j['failed'][0]['error_msg'] == "Adv Prefix length lesser than 64 is not supported"        
+        assert j['failed'][0]['error_msg'] == "Adv Prefix length lesser than 60 is not supported"
 
         # Append and remove
         route = {


### PR DESCRIPTION
Set allowed IPv6 pfx len to be 60
Fix for https://github.com/sonic-net/sonic-restapi/pull/134