### PR TITLE
[Security] Fix the redis security issue CVE-2023-28858 and CVE-2023-28859

### DIFF
--- a/azurepipeline.yml
+++ b/azurepipeline.yml
@@ -10,7 +10,7 @@ pr:
 jobs:
 - job: Build
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
 
   variables:
     DIFF_COVER_CHECK_THRESHOLD: 80
@@ -58,7 +58,7 @@ jobs:
         set -ex
         # Install .NET CORE
         curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/ubuntu/18.04/prod
+        sudo apt-add-repository https://packages.microsoft.com/ubuntu/20.04/prod
         sudo apt-get update
         sudo apt-get install -y dotnet-sdk-5.0
       displayName: "Install .NET CORE"

--- a/azurepipeline.yml
+++ b/azurepipeline.yml
@@ -21,6 +21,11 @@ jobs:
     - checkout: self
       clean: true
 
+    # TODO: upgrade to python3
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '2.7'
+
     - script: |
         set -ex
         ./build.sh

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
-redis==4.3.6
+redis==4.5.4
 requests==2.25.0

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
-redis==2.10.5
+redis==4.3.6
 requests==2.25.0


### PR DESCRIPTION
[Security] Fix the redis security issue CVE-2023-28858 and CVE-2023-28859

Upgrade the redis version from 2.10.5 to 4.5.4

```
|Alert title                             |Affected component                      |Severity                      |Due date                      |
|________________________________________|________________________________________|______________________________|______________________________|
|CVE-2023-28858                          |redis 2.10.5                            |High                          |2023-04-27T13:44:39.1802657Z  |

```