### PR TITLE
[Ci] Upgrade python 2 to python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
       libzmq5-dev
 
 COPY debs /debs
-RUN dpkg -i /debs/*.deb
+RUN dpkg -i /debs/*.deb || apt-get --fix-broken -y install
 RUN rm -fr /debs
 
 COPY supervisor/supervisor.conf /etc/supervisor/conf.d/

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -27,7 +27,7 @@ RUN apt-get update \
       pkg-config
 
 COPY debs /debs
-RUN dpkg -i /debs/*.deb
+RUN dpkg -i /debs/*.deb || apt-get --fix-broken -y install
 RUN rm -fr /debs
 
 #RUN export VERSION=0.9.3 \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -18,7 +18,7 @@ RUN apt-get update \
       libzmq5-dev
 
 COPY debs /debs
-RUN dpkg -i /debs/*.deb
+RUN dpkg -i /debs/*.deb || apt-get --fix-broken -y install
 RUN rm -fr /debs
 
 # Adjust redis configurations

--- a/azurepipeline.yml
+++ b/azurepipeline.yml
@@ -21,11 +21,6 @@ jobs:
     - checkout: self
       clean: true
 
-    # TODO: upgrade to python3
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '2.7'
-
     - script: |
         set -ex
         ./build.sh
@@ -40,8 +35,7 @@ jobs:
 
     - script: |
         set -ex
-        pip install requests
-        pip install redis
+        pip install -r test/requirements.txt
         pip install -U pytest
         cd test
         pytest -vv

--- a/copy.sh
+++ b/copy.sh
@@ -1,7 +1,7 @@
 set -e
 
-wget -O debs/libhiredis0.14_0.14.0-3~bpo9+1_amd64.deb  'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibhiredis0.14_0.14.0-3~bpo9%2B1_amd64.deb'
-wget -O debs/libhiredis-dev_0.14.0-3~bpo9+1_amd64.deb  'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibhiredis-dev_0.14.0-3~bpo9%2B1_amd64.deb'
+wget -O debs/libhiredis0.14_0.14.1-1_amd64.deb  'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibhiredis0.14_0.14.1-1_amd64.deb'
+wget -O debs/libhiredis-dev_0.14.1-1_amd64.deb  'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibhiredis-dev_0.14.1-1_amd64.deb'
 wget -O debs/libnl-3-200_3.5.0-1_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libnl-3-200_3.5.0-1_amd64.deb'
 wget -O debs/libnl-3-dev_3.5.0-1_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libnl-3-dev_3.5.0-1_amd64.deb'
 wget -O debs/libnl-genl-3-200_3.5.0-1_amd64.deb  'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libnl-genl-3-200_3.5.0-1_amd64.deb'

--- a/dependencies.conf
+++ b/dependencies.conf
@@ -4,8 +4,8 @@
     "debian": "buster",
     "arch": "amd64",
     "dependencies": [
-                        "libhiredis0.14_0.14.0-3~bpo9+1",
-                        "libhiredis-dev_0.14.0-3~bpo9+1",
+                        "libhiredis0.14_0.14.1-1",
+                        "libhiredis-dev_0.14.1-1",
                         "libnl-3-200_3.5.0-1",
                         "libnl-3-dev_3.5.0-1",
                         "libnl-genl-3-200_3.5.0-1",

--- a/test/apitest.py
+++ b/test/apitest.py
@@ -248,9 +248,9 @@ class rest_api_client(unittest.TestCase):
        for route in routes_arr:
            route_table = self.db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(vnet_num_mapped)+':'+route['ip_prefix'])
            self.assertEqual(route_table, {
-                            b'endpoint' : route['nexthop'],
-                            b'mac_address' : route['mac_address'],
-                            b'vni' : str(route['vnid'])
+                            b'endpoint' : route['nexthop'].encode(),
+                            b'mac_address' : route['mac_address'].encode(),
+                            b'vni' : str(route['vnid']).encode()
                           })
 
     def check_routes_dont_exist_in_tun_tb(self, vnet_num_mapped, routes_arr):
@@ -262,8 +262,8 @@ class rest_api_client(unittest.TestCase):
        for route in routes_arr:
            route_table = self.db.hgetall(LOCAL_ROUTE_TB + ':' + VNET_NAME_PREF +str(vnet_num_mapped)+':'+route['ip_prefix'])
            self.assertEqual(route_table, {
-                            b'nexthop' : route['nexthop'],
-                            b'ifname' : route['ifname']
+                            b'nexthop' : route['nexthop'].encode(),
+                            b'ifname' : route['ifname'].encode()
                           })
 
     def check_routes_dont_exist_in_loc_route_tb(self, vnet_num_mapped, routes_arr):
@@ -1186,7 +1186,7 @@ class ra_client_positive_tests(rest_api_client):
     def test_local_subnet_route_addition(self):
         self.post_generic_vlan_and_deps()
         local_route_table = self.db.hgetall(LOCAL_ROUTE_TB + ':' + VNET_NAME_PREF +str(1)+':10.1.1.0/24')
-        self.assertEqual(local_route_table, {b'ifname' : VLAN_NAME_PREF + '2'})
+        self.assertEqual(local_route_table, {b'ifname' : VLAN_NAME_PREF.encode() + b'2'})
         r = self.delete_config_vlan(2)
         self.assertEqual(r.status_code, 204)
         local_route_table = self.db.hgetall(LOCAL_ROUTE_TB + ':' + VNET_NAME_PREF +str(1)+':10.1.1.0/24')

--- a/test/restapi_client.py
+++ b/test/restapi_client.py
@@ -250,9 +250,9 @@ class RESTAPI_client:
        for route in routes_arr:
            route_table = self.db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(vnet_num_mapped)+':'+route['ip_prefix'])
            assert route_table == {
-                            b'endpoint' : route['nexthop'],
-                            b'mac_address' : route['mac_address'],
-                            b'vni' : str(route['vnid'])
+                            b'endpoint' : route['nexthop'].encode(),
+                            b'mac_address' : route['mac_address'].encode(),
+                            b'vni' : str(route['vnid']).encode()
                           }
 
     def check_routes_dont_exist_in_tun_tb(self, vnet_num_mapped, routes_arr):
@@ -264,8 +264,8 @@ class RESTAPI_client:
        for route in routes_arr:
            route_table = self.db.hgetall(LOCAL_ROUTE_TB + ':' + VNET_NAME_PREF +str(vnet_num_mapped)+':'+route['ip_prefix'])
            assert route_table == {
-                            b'nexthop' : route['nexthop'],
-                            b'ifname' : route['ifname']
+                            b'nexthop' : route['nexthop'].encode(),
+                            b'ifname' : route['ifname'].encode()
                           }
 
     def check_routes_dont_exist_in_loc_route_tb(self, vnet_num_mapped, routes_arr):

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -2,7 +2,6 @@
 
 import logging
 import json
-from collections import OrderedDict
 
 # DB Names
 VXLAN_TUNNEL_TB   = "VXLAN_TUNNEL"
@@ -28,7 +27,7 @@ DELETE_DEP = 2
 
 sorted_org = sorted
 def sorted(l):
-    return sorted_org(l, key = lambda x : str(OrderedDict(x.items())) if isinstance(x, dict) else x)
+    return sorted_org(l, key = lambda x : str(sorted_org(x.items())) if isinstance(x, dict) else x)
 
 class TestRestApiPositive:
     """Normal behaviour tests"""

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -468,14 +468,14 @@ class TestRestApiPositive:
                 assert k_vnet1[key] == j_vnet1[key]
             else:
                 #print("is type list",value)
-                assert sorted(value) == sorted(list(k_vnet1.values())[0])
+                assert sorted(value) == sorted(k_vnet1['attr'])
         for key,value in j_vnet2.items():
             if type(value)!=list:
                 #print("not type list",value)
                 assert k_vnet2[key] == j_vnet2[key]
             else:
                 #print("is type list",value)
-                assert sorted(value) == sorted(k_vnet2.values()[0])
+                assert sorted(value) == sorted(k_vnet2['attr'])
 
     def test_get_vlans_per_vnetid_4digitvlans(self, setup_restapi_client):
         _, _, _, restapi_client = setup_restapi_client
@@ -808,7 +808,7 @@ class TestRestApiPositive:
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         assert route_table == {b'endpoint' : route['nexthop'].encode(),
-                                       b'mac_address' : route['mac_address']
+                                       b'mac_address' : route['mac_address'].encode()
                                       }
         del route['cmd']
         routes = list()
@@ -1098,7 +1098,7 @@ class TestRestApiPositive:
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         assert route_table == {b'endpoint' : route['nexthop'].encode(),
-                                       b'mac_address' : route['mac_address']
+                                       b'mac_address' : route['mac_address'].encode()
                                       }
         del route['cmd']
         routes = list()
@@ -1722,7 +1722,7 @@ class TestRestApiPositive:
         db, _, _, restapi_client = setup_restapi_client
         restapi_client.post_generic_vlan_and_deps()
         local_route_table = db.hgetall(LOCAL_ROUTE_TB + ':' + VNET_NAME_PREF +str(1)+':10.1.1.0/24')
-        assert local_route_table == {b'ifname' : VLAN_NAME_PREF + '2'}
+        assert local_route_table == {b'ifname' : VLAN_NAME_PREF.encode() + b'2'}
         r = restapi_client.delete_config_vlan(2)
         assert r.status_code == 204
         local_route_table = db.hgetall(LOCAL_ROUTE_TB + ':' + VNET_NAME_PREF +str(1)+':10.1.1.0/24')

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -163,10 +163,10 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         assert vrouter_table == {
-							b'vxlan_tunnel': b'default_vxlan_tunnel',
-							b'vni': b'1001',
-							b'guid': b'vnet-guid-1'
-							}
+                                                        b'vxlan_tunnel': b'default_vxlan_tunnel',
+                                                        b'vni': b'1001',
+                                                        b'guid': b'vnet-guid-1'
+                                                        }
 
     def test_post_vrouter_duplicate(self, setup_restapi_client):
         _, _, configdb, restapi_client = setup_restapi_client
@@ -178,10 +178,10 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         assert vrouter_table == {
-							b'vxlan_tunnel': b'default_vxlan_tunnel',
-							b'vni': b'1001',
-							b'guid': b'vnet-guid-1'
-							}
+                                                        b'vxlan_tunnel': b'default_vxlan_tunnel',
+                                                        b'vni': b'1001',
+                                                        b'guid': b'vnet-guid-1'
+                                                        }
 
         r = restapi_client.post_config_vrouter_vrf_id("vnet-guid-2", {
             'vnid': 1001
@@ -204,7 +204,7 @@ class TestRestApiPositive:
                     b'vni': b'1001',
                     b'guid': b'vnet-guid-1',
                     b'advertise_prefix': b'false'
-				}
+                                }
         r = restapi_client.post_config_vrouter_vrf_id("vnet-guid-2", {
             'vnid': 1002,
             'advertise_prefix': 'true'
@@ -248,11 +248,11 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         assert vrouter_table == {
-							b'vxlan_tunnel': b'default_vxlan_tunnel',
-							b'vni': b'2001',
-							b'guid': b'Vnet-default',
+                                                        b'vxlan_tunnel': b'default_vxlan_tunnel',
+                                                        b'vni': b'2001',
+                                                        b'guid': b'Vnet-default',
                             b'scope': b'default'
-							}
+                                                        }
 
     def test_get_vrouter(self, setup_restapi_client):
         _, _, _, restapi_client = setup_restapi_client
@@ -296,7 +296,7 @@ class TestRestApiPositive:
              vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF +str(i))
              assert vrouter_table == {
                      b'vxlan_tunnel': b'default_vxlan_tunnel',
-                     b'vni': b'100'+str(i),
+                     b'vni': b'100'+str(i).encode(),
                      b'guid': b'vnet-guid-'+str(i)
                      }
 
@@ -309,8 +309,8 @@ class TestRestApiPositive:
              vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF +str(i))
              assert vrouter_table == {
                      b'vxlan_tunnel': b'default_vxlan_tunnel',
-                     b'vni': b'100'+str(i+3),
-                     b'guid': b'vnet-guid-'+str(i+3)
+                     b'vni': b'100'+str(i+3).encode(),
+                     b'guid': b'vnet-guid-'+str(i+3).encode()
                      }
 
              r = restapi_client.post_config_vrouter_vrf_id("vnet-guid-"+str(i+6), {'vnid': 1006+i})
@@ -319,8 +319,8 @@ class TestRestApiPositive:
              vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF +str(i+3))
              assert vrouter_table == {
                      b'vxlan_tunnel': b'default_vxlan_tunnel',
-                     b'vni': b'100'+str(i+6),
-                     b'guid': b'vnet-guid-'+str(i+6)
+                     b'vni': b'100'+str(i+6).encode(),
+                     b'guid': b'vnet-guid-'+str(i+6).encode()
                      }
              
 
@@ -340,7 +340,7 @@ class TestRestApiPositive:
             'attr': {}
         }
         vlan_table = configdb.hgetall(VLAN_TB + '|' + VLAN_NAME_PREF + '2')
-        assert vlan_table == {'host_ifname': 'MonVlan2', b'vlanid': b'2'}
+        assert vlan_table == {b'host_ifname': b'MonVlan2', b'vlanid': b'2'}
         vlan_intf_table = configdb.hgetall(VLAN_INTF_TB + '|' + VLAN_NAME_PREF + '2')
         assert vlan_intf_table == {}
 
@@ -366,9 +366,9 @@ class TestRestApiPositive:
             'attr': {'vnet_id':'vnet-guid-1'}
         }
         vlan_table = configdb.hgetall(VLAN_TB + '|' + VLAN_NAME_PREF + '2')
-        assert vlan_table == {'host_ifname': 'MonVlan2', b'vlanid': b'2'}
+        assert vlan_table == {b'host_ifname': b'MonVlan2', b'vlanid': b'2'}
         vlan_intf_table = configdb.hgetall(VLAN_INTF_TB + '|' + VLAN_NAME_PREF + '2')
-        assert vlan_intf_table == {b'proxy_arp': b'enabled', b'vnet_name': VNET_NAME_PREF + '1'}
+        assert vlan_intf_table == {b'proxy_arp': b'enabled', b'vnet_name': VNET_NAME_PREF.encode() + b'1'}
 
         # delete
         r = restapi_client.delete_config_vlan(2)
@@ -394,7 +394,7 @@ class TestRestApiPositive:
             'attr': {'ip_prefix':'10.0.1.1/24'}
         }
         vlan_table = configdb.hgetall(VLAN_TB + '|' + VLAN_NAME_PREF + '2')
-        assert vlan_table == {'host_ifname': 'MonVlan2', b'vlanid': b'2'}
+        assert vlan_table == {b'host_ifname': b'MonVlan2', b'vlanid': b'2'}
         vlan_intf_table = configdb.hgetall(VLAN_INTF_TB + '|' + VLAN_NAME_PREF + '2|10.0.1.1/24')
         assert vlan_intf_table == {b'':b''}
         vlan_intf_table = configdb.hgetall(VLAN_INTF_TB + '|' + VLAN_NAME_PREF + '2')
@@ -424,11 +424,11 @@ class TestRestApiPositive:
             'attr': {'vnet_id' : 'vnet-guid-1', 'ip_prefix':'10.0.1.1/24'}
         }
         vlan_table = configdb.hgetall(VLAN_TB + '|' + VLAN_NAME_PREF + '2')
-        assert vlan_table == {'host_ifname': 'MonVlan2', b'vlanid': b'2'}
+        assert vlan_table == {b'host_ifname': b'MonVlan2', b'vlanid': b'2'}
         vlan_intf_table = configdb.hgetall(VLAN_INTF_TB + '|' + VLAN_NAME_PREF + '2|10.0.1.1/24')
         assert vlan_intf_table == {b'':b''}
         vlan_intf_table = configdb.hgetall(VLAN_INTF_TB + '|' + VLAN_NAME_PREF + '2')
-        assert vlan_intf_table == {b'proxy_arp': b'enabled', b'vnet_name': VNET_NAME_PREF+'1'}
+        assert vlan_intf_table == {b'proxy_arp': b'enabled', b'vnet_name': VNET_NAME_PREF.encode()+b'1'}
 
         # delete
         r = restapi_client.delete_config_vlan(2)
@@ -462,14 +462,14 @@ class TestRestApiPositive:
         j_vnet2 = json.loads(r_vnet2.text)
         k_vnet1 = {"vnet_id":"vnet-guid-1","attr":[{"vlan_id":3,"ip_prefix":"10.0.4.1/24"},{"vlan_id":4,"ip_prefix":"10.0.3.1/24"}]}
         k_vnet2 = {"vnet_id":"vnet-guid-2","attr":[{"vlan_id":5,"ip_prefix":"10.2.4.1/24"},{"vlan_id":6,"ip_prefix":"10.2.3.1/24"}]}
-        for key,value in j_vnet1.iteritems():
+        for key,value in j_vnet1.itmes():
             if type(value)!=list:
                 #print("not type list",value)
                 assert k_vnet1[key] == j_vnet1[key]
             else:
                 #print("is type list",value)
                 assert sorted(value) == sorted(k_vnet1.values()[0])
-        for key,value in j_vnet2.iteritems():
+        for key,value in j_vnet2.itmes():
             if type(value)!=list:
                 #print("not type list",value)
                 assert k_vnet2[key] == j_vnet2[key]
@@ -499,14 +499,14 @@ class TestRestApiPositive:
         j2 = json.loads(r2.text)
         k = {"vnet_id":"vnet-guid-1","attr":[{"vlan_id":1111,"ip_prefix":"10.0.1.1/24"},{"vlan_id":2222,"ip_prefix":"10.0.2.1/24"}]}
         k2 = {"vnet_id":"vnet-guid-2","attr":[{"vlan_id":3000},{"vlan_id":4000,"ip_prefix":"10.2.2.1/24"}]}
-        for key,value in j.iteritems():
+        for key,value in j.itmes():
             if type(value)!=list:
                 #print("not type list",value)
                 assert k[key] == j[key]
             else:
                 #print("is type list",value)
                 assert sorted(value) == sorted(k.values()[0]) 
-        for key,value in j2.iteritems():
+        for key,value in j2.itmes():
             if type(value)!=list:
                 #print("not type list",value)
                 assert k2[key] == j2[key]
@@ -531,7 +531,7 @@ class TestRestApiPositive:
         r = restapi_client.get_config_vlans_all()
         j = json.loads(r.text)
         k = {"attr":[{"vlan_id":3000,"ip_prefix":"10.0.1.1/24","vnet_id":"vnet-guid-1"},{"vlan_id":3001,"vnet_id":"vnet-guid-1"}]}
-        for key,value in j.iteritems():
+        for key,value in j.itmes():
             if type(value)!=list:
                 assert k[key] == j[key]
                 return
@@ -757,7 +757,7 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop']}
+        assert route_table == {b'endpoint' : route['nexthop'].encode()}
         del route['cmd']
         routes = list()
         routes.append(route)
@@ -773,7 +773,7 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop']}
+        assert route_table == {b'endpoint' : route['nexthop'].encode()}
 
         # Delete route
         route['cmd'] = 'delete'
@@ -788,8 +788,8 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                       b'vni' : str(route['vnid'])
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                       b'vni' : str(route['vnid'].encode())
                                       }
         del route['cmd']
         routes = list()
@@ -807,7 +807,7 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
                                        b'mac_address' : route['mac_address']
                                       }
         del route['cmd']
@@ -825,10 +825,10 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                       b'vni': str(route['vnid']), 
-                                       b'mac_address' : route['mac_address'],
-                                       b'endpoint_monitor': route['nexthop_monitor']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                       b'vni': str(route['vnid']).encode(),
+                                       b'mac_address' : route['mac_address'].encode(),
+                                       b'endpoint_monitor': route['nexthop_monitor'].encode()
                                       }
         del route['cmd']
         routes = list()
@@ -847,10 +847,10 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                       b'vni': str(route['vnid']), 
-                                       b'mac_address' : route['mac_address'],
-                                       b'weight': route['weight']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                       b'vni': str(route['vnid']).encode(),
+                                       b'mac_address' : route['mac_address'].encode(),
+                                       b'weight': route['weight'].encode()
                                       }
         del route['cmd']
         routes = list()
@@ -870,10 +870,10 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                       b'vni': str(route['vnid']), 
-                                       b'mac_address' : route['mac_address'],
-                                       b'profile': route['profile']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                       b'vni': str(route['vnid']).encode(),
+                                       b'mac_address' : route['mac_address'].encode(),
+                                       b'profile': route['profile'].encode()
                                       }
         del route['cmd']
         routes = list()
@@ -890,11 +890,11 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                       b'vni': str(route['vnid']), 
-                                       b'mac_address' : route['mac_address'],
-                                       b'profile': route['profile'],
-                                       b'primary': route['primary']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                       b'vni': str(route['vnid']).encode(),
+                                       b'mac_address' : route['mac_address'].encode(),
+                                       b'profile': route['profile'].encode(),
+                                       b'primary': route['primary'].encode()
                                       }
         del route['cmd']
         routes = list()
@@ -913,12 +913,12 @@ class TestRestApiPositive:
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         route['nexthop'] = '100.3.152.32,200.3.152.32,200.3.152.33'
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor'],
-                                b'vni': str(route['vnid']), 
-                                b'mac_address' : route['mac_address'],
-                                b'profile': route['profile'],
-                                b'primary': route['primary']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                b'endpoint_monitor': route['nexthop_monitor'].encode(),
+                                b'vni': str(route['vnid']).encode(),
+                                b'mac_address' : route['mac_address'].encode(),
+                                b'profile': route['profile'].encode(),
+                                b'primary': route['primary'].encode()
                                 }
         del route['cmd']
         routes = list()
@@ -937,12 +937,12 @@ class TestRestApiPositive:
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         route['nexthop'] = '100.3.152.32,200.3.152.33'
         route['nexthop_monitor'] = '100.3.152.32,200.3.152.33'
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor'],
-                                b'vni': str(route['vnid']), 
-                                b'mac_address' : route['mac_address'],
-                                b'profile': route['profile'],
-                                b'primary': route['primary']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                b'endpoint_monitor': route['nexthop_monitor'].encode(),
+                                b'vni': str(route['vnid']).encode(),
+                                b'mac_address' : route['mac_address'].encode(),
+                                b'profile': route['profile'].encode(),
+                                b'primary': route['primary'].encode()
                                 }
         del route['cmd']
         routes = list()
@@ -967,11 +967,11 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor'],
-                                b'vni': str(route['vnid']), 
-                                b'mac_address' : route['mac_address'],
-                                b'profile': route['profile']                                
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                b'endpoint_monitor': route['nexthop_monitor'].encode(),
+                                b'vni': str(route['vnid']).encode(),
+                                b'mac_address' : route['mac_address'].encode(),
+                                b'profile': route['profile'].encode()
                                 }
         del route['cmd']
         routes = list()
@@ -999,10 +999,10 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                       b'endpoint_monitor': route['nexthop_monitor'],
-                                       b'primary': route['primary'],
-                                       b'monitoring': route['monitoring']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                       b'endpoint_monitor': route['nexthop_monitor'].encode(),
+                                       b'primary': route['primary'].encode(),
+                                       b'monitoring': route['monitoring'].encode()
                                       }
         del route['cmd']
         routes = list()
@@ -1019,11 +1019,11 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                       b'endpoint_monitor': route['nexthop_monitor'],
-                                       b'primary': route['primary'],
-                                       b'monitoring': route['monitoring'],
-                                       b'adv_prefix': route['adv_prefix']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                       b'endpoint_monitor': route['nexthop_monitor'].encode(),
+                                       b'primary': route['primary'].encode(),
+                                       b'monitoring': route['monitoring'].encode(),
+                                       b'adv_prefix': route['adv_prefix'].encode()
                                       }
         del route['cmd']
         routes = list()
@@ -1046,7 +1046,7 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop']}
+        assert route_table == {b'endpoint' : route['nexthop'].encode()}
         del route['cmd']
         routes = list()
         routes.append(route)
@@ -1063,7 +1063,7 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop']}
+        assert route_table == {b'endpoint' : route['nexthop'].encode()}
 
         # Delete route
         route['cmd'] = 'delete'
@@ -1078,8 +1078,8 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                       b'vni' : str(route['vnid'])
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                       b'vni' : str(route['vnid'].encode())
                                       }
         del route['cmd']
         routes = list()
@@ -1097,7 +1097,7 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
                                        b'mac_address' : route['mac_address']
                                       }
         del route['cmd']
@@ -1115,10 +1115,10 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                       b'vni': str(route['vnid']), 
-                                       b'mac_address' : route['mac_address'],
-                                       b'endpoint_monitor': route['nexthop_monitor']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                       b'vni': str(route['vnid']).encode(),
+                                       b'mac_address' : route['mac_address'].encode(),
+                                       b'endpoint_monitor': route['nexthop_monitor'].encode()
                                       }
         del route['cmd']
         routes = list()
@@ -1137,10 +1137,10 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                       b'vni': str(route['vnid']), 
-                                       b'mac_address' : route['mac_address'],
-                                       b'weight': route['weight']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                       b'vni': str(route['vnid']).encode(),
+                                       b'mac_address' : route['mac_address'].encode(),
+                                       b'weight': route['weight'].encode()
                                       }
         del route['cmd']
         routes = list()
@@ -1160,10 +1160,10 @@ class TestRestApiPositive:
         r = restapi_client.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                       b'vni': str(route['vnid']), 
-                                       b'mac_address' : route['mac_address'],
-                                       b'profile': route['profile']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                       b'vni': str(route['vnid']).encode(),
+                                       b'mac_address' : route['mac_address'].encode(),
+                                       b'profile': route['profile'].encode()
                                       }
         del route['cmd']
         routes = list()
@@ -1182,11 +1182,11 @@ class TestRestApiPositive:
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         route['nexthop'] = 'bbc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b803:53c6:d1e5:6db5:82cc:c35a:c1d8:4404,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor'],
-                                b'vni': str(route['vnid']), 
-                                b'mac_address' : route['mac_address'],
-                                b'profile': route['profile']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                b'endpoint_monitor': route['nexthop_monitor'].encode(),
+                                b'vni': str(route['vnid']).encode(),
+                                b'mac_address' : route['mac_address'].encode(),
+                                b'profile': route['profile'].encode()
                                 }
         del route['cmd']
         routes = list()
@@ -1205,11 +1205,11 @@ class TestRestApiPositive:
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         route['nexthop'] = 'bbc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
         route['nexthop_monitor'] = 'ccc4:e3f9:3afd:9299:f009:34b6:2fe6:fb90,b703:53a8:d1e5:6db5:82cc:c35a:c1d8:4404'
-        assert route_table == {b'endpoint' : route['nexthop'],
-                                b'endpoint_monitor': route['nexthop_monitor'],
-                                b'vni': str(route['vnid']), 
-                                b'mac_address' : route['mac_address'],
-                                b'profile': route['profile']
+        assert route_table == {b'endpoint' : route['nexthop'].encode(),
+                                b'endpoint_monitor': route['nexthop_monitor'].encode(),
+                                b'vni': str(route['vnid']).encode(),
+                                b'mac_address' : route['mac_address'].encode(),
+                                b'profile': route['profile'].encode()
                                 }
         del route['cmd']
         routes = list()
@@ -1330,7 +1330,7 @@ class TestRestApiPositive:
              routes.append({'cmd':'add', 
                             'ip_prefix':'10.2.'+str(i)+'.0/24', 
                             'nexthop':'192.168.2.'+str(i), 
-                            'vnid': 1 + i%5, 
+                            'vnid': 1 + i%5,
                             'mac_address':'00:08:aa:bb:cd:'+hex(15+i)[2:]})
        
         # Patch add

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -505,14 +505,14 @@ class TestRestApiPositive:
                 assert k[key] == j[key]
             else:
                 #print("is type list",value)
-                assert sorted(value) == sorted(k.values()[0]) 
+                assert sorted(value) == sorted(k['attr'])
         for key,value in j2.items():
             if type(value)!=list:
                 #print("not type list",value)
                 assert k2[key] == j2[key]
             else:
                 #print("is type list",value)
-                assert sorted(value) == sorted(k2.values()[0])
+                assert sorted(value) == sorted(k2['attr'])
 
     # Vlan Get
     def test_get_all_vlans(self, setup_restapi_client):

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -25,6 +25,9 @@ RESRC_EXISTS = 0
 DEP_MISSING = 1
 DELETE_DEP = 2
 
+sorted_org = sorted
+def sorted(l):
+    return sorted_org([str(e) for e in l])
 
 class TestRestApiPositive:
     """Normal behaviour tests"""

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -2,6 +2,7 @@
 
 import logging
 import json
+from collections import OrderedDict
 
 # DB Names
 VXLAN_TUNNEL_TB   = "VXLAN_TUNNEL"
@@ -27,7 +28,7 @@ DELETE_DEP = 2
 
 sorted_org = sorted
 def sorted(l):
-    return sorted_org([str(e) for e in l])
+    return sorted_org(l, key = lambda x : str(OrderedDict(x.items())) if isinstance(x, dict) else x)
 
 class TestRestApiPositive:
     """Normal behaviour tests"""
@@ -163,10 +164,10 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         assert vrouter_table == {
-                                                        b'vxlan_tunnel': b'default_vxlan_tunnel',
-                                                        b'vni': b'1001',
-                                                        b'guid': b'vnet-guid-1'
-                                                        }
+                                  b'vxlan_tunnel': b'default_vxlan_tunnel',
+                                  b'vni': b'1001',
+                                  b'guid': b'vnet-guid-1'
+                                }
 
     def test_post_vrouter_duplicate(self, setup_restapi_client):
         _, _, configdb, restapi_client = setup_restapi_client
@@ -178,10 +179,10 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         assert vrouter_table == {
-                                                        b'vxlan_tunnel': b'default_vxlan_tunnel',
-                                                        b'vni': b'1001',
-                                                        b'guid': b'vnet-guid-1'
-                                                        }
+                                  b'vxlan_tunnel': b'default_vxlan_tunnel',
+                                  b'vni': b'1001',
+                                  b'guid': b'vnet-guid-1'
+                                }
 
         r = restapi_client.post_config_vrouter_vrf_id("vnet-guid-2", {
             'vnid': 1001
@@ -248,10 +249,10 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         assert vrouter_table == {
-                                                        b'vxlan_tunnel': b'default_vxlan_tunnel',
-                                                        b'vni': b'2001',
-                                                        b'guid': b'Vnet-default',
-                            b'scope': b'default'
+                    b'vxlan_tunnel': b'default_vxlan_tunnel',
+                    b'vni': b'2001',
+                    b'guid': b'Vnet-default',
+                    b'scope': b'default'
                                                         }
 
     def test_get_vrouter(self, setup_restapi_client):
@@ -297,7 +298,7 @@ class TestRestApiPositive:
              assert vrouter_table == {
                      b'vxlan_tunnel': b'default_vxlan_tunnel',
                      b'vni': b'100'+str(i).encode(),
-                     b'guid': b'vnet-guid-'+str(i)
+                     b'guid': b'vnet-guid-'+str(i).encode()
                      }
 
         for i in range (1,4):
@@ -462,14 +463,14 @@ class TestRestApiPositive:
         j_vnet2 = json.loads(r_vnet2.text)
         k_vnet1 = {"vnet_id":"vnet-guid-1","attr":[{"vlan_id":3,"ip_prefix":"10.0.4.1/24"},{"vlan_id":4,"ip_prefix":"10.0.3.1/24"}]}
         k_vnet2 = {"vnet_id":"vnet-guid-2","attr":[{"vlan_id":5,"ip_prefix":"10.2.4.1/24"},{"vlan_id":6,"ip_prefix":"10.2.3.1/24"}]}
-        for key,value in j_vnet1.itmes():
+        for key,value in j_vnet1.items():
             if type(value)!=list:
                 #print("not type list",value)
                 assert k_vnet1[key] == j_vnet1[key]
             else:
                 #print("is type list",value)
                 assert sorted(value) == sorted(k_vnet1.values()[0])
-        for key,value in j_vnet2.itmes():
+        for key,value in j_vnet2.items():
             if type(value)!=list:
                 #print("not type list",value)
                 assert k_vnet2[key] == j_vnet2[key]
@@ -499,14 +500,14 @@ class TestRestApiPositive:
         j2 = json.loads(r2.text)
         k = {"vnet_id":"vnet-guid-1","attr":[{"vlan_id":1111,"ip_prefix":"10.0.1.1/24"},{"vlan_id":2222,"ip_prefix":"10.0.2.1/24"}]}
         k2 = {"vnet_id":"vnet-guid-2","attr":[{"vlan_id":3000},{"vlan_id":4000,"ip_prefix":"10.2.2.1/24"}]}
-        for key,value in j.itmes():
+        for key,value in j.items():
             if type(value)!=list:
                 #print("not type list",value)
                 assert k[key] == j[key]
             else:
                 #print("is type list",value)
                 assert sorted(value) == sorted(k.values()[0]) 
-        for key,value in j2.itmes():
+        for key,value in j2.items():
             if type(value)!=list:
                 #print("not type list",value)
                 assert k2[key] == j2[key]
@@ -531,7 +532,7 @@ class TestRestApiPositive:
         r = restapi_client.get_config_vlans_all()
         j = json.loads(r.text)
         k = {"attr":[{"vlan_id":3000,"ip_prefix":"10.0.1.1/24","vnet_id":"vnet-guid-1"},{"vlan_id":3001,"vnet_id":"vnet-guid-1"}]}
-        for key,value in j.itmes():
+        for key,value in j.items():
             if type(value)!=list:
                 assert k[key] == j[key]
                 return

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -468,7 +468,7 @@ class TestRestApiPositive:
                 assert k_vnet1[key] == j_vnet1[key]
             else:
                 #print("is type list",value)
-                assert sorted(value) == sorted(k_vnet1.values()[0])
+                assert sorted(value) == sorted(list(k_vnet1.values())[0])
         for key,value in j_vnet2.items():
             if type(value)!=list:
                 #print("not type list",value)
@@ -789,7 +789,7 @@ class TestRestApiPositive:
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         assert route_table == {b'endpoint' : route['nexthop'].encode(),
-                                       b'vni' : str(route['vnid'].encode())
+                                       b'vni' : str(route['vnid']).encode()
                                       }
         del route['cmd']
         routes = list()
@@ -1079,7 +1079,7 @@ class TestRestApiPositive:
         assert r.status_code == 204
         route_table = db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         assert route_table == {b'endpoint' : route['nexthop'].encode(),
-                                       b'vni' : str(route['vnid'].encode())
+                                       b'vni' : str(route['vnid']).encode()
                                       }
         del route['cmd']
         routes = list()


### PR DESCRIPTION
[Ci] Upgrade python 2 to python 3
Fix unit test failure

One of example as below:
```
$ python2 -c 'print(sorted({"1",b"2"}))'
['1', '2']
```
```
$ python3 -c 'print(sorted({"1",b"2"}))' 
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: '<' not supported between instances of 'bytes' and 'str'
```