### PR TITLE
Remove command to install libhiredis deb file

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -18,6 +18,7 @@ RUN apt-get update \
       g++ \
       git \
       libboost-serialization1.71-dev \
+      libhiredis-dev \
       libzmq5-dev \
       libevent-dev \
       libssl-dev \

--- a/dependencies.conf
+++ b/dependencies.conf
@@ -4,8 +4,6 @@
     "debian": "buster",
     "arch": "amd64",
     "dependencies": [
-                        "libhiredis0.14_0.14.1-1",
-                        "libhiredis-dev_0.14.1-1",
                         "libnl-3-200_3.5.0-1",
                         "libnl-3-dev_3.5.0-1",
                         "libnl-genl-3-200_3.5.0-1",


### PR DESCRIPTION
libhiredis is now used as-is from the slave container, since we're not making any changes to this package. See also
sonic-net/sonic-buildimage#15633.