### PR TITLE
[Tunnel] Support co-existence of IPv4 and IPv6 tunnels

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,22 @@
+name: Semgrep
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
+      - '201[7-9][0-1][0-9]'
+      - '202[0-9][0-1][0-9]'
+
+jobs:
+  semgrep:
+    if: github.repository_owner == 'sonic-net'
+    name: Semgrep
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - uses: actions/checkout@v3
+      - run: semgrep ci
+        env:
+           SEMGREP_RULES: p/default

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1073,9 +1073,12 @@ func ConfigVrouterVrfIdPost(w http.ResponseWriter, r *http.Request) {
 
     guid := CacheGetVniId(uint32(attr.Vnid))
     if guid != "" {
-        WriteRequestErrorWithSubCode(w, http.StatusConflict, RESRC_EXISTS,
-              "Object already exists: {\"vni\":\"" + strconv.Itoa(attr.Vnid) + "\", \"vnet_name\":\"" + guid +"\"}", []string{}, "")
-        return
+        // Default Vnets can have same Vnid
+        if !(strings.Contains(guid, "Vnet-default")) {
+            WriteRequestErrorWithSubCode(w, http.StatusConflict, RESRC_EXISTS,
+                  "Object already exists: {\"vni\":\"" + strconv.Itoa(attr.Vnid) + "\", \"vnet_name\":\"" + guid +"\"}", []string{}, "")
+            return
+        }
     }
 
     vnet_id = CacheGenAndSetVnetGuidId(vars["vnet_name"], uint32(attr.Vnid))

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1048,7 +1048,7 @@ func ConfigVrouterVrfIdPost(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-    if kv == nil and kv_4 == nil {
+    if kv == nil && kv_4 == nil {
         WriteRequestErrorWithSubCode(w, http.StatusConflict, DEP_MISSING,
               "Default VxLAN VTEP must be created prior to creating VRF", []string{"tunnel"}, "")
         return

--- a/test/apitest.py
+++ b/test/apitest.py
@@ -367,7 +367,7 @@ class ra_client_positive_tests(rest_api_client):
         })
         self.assertEqual(r.status_code, 409)
 
-        tunnel_table = self.configdb.hgetall(VXLAN_TUNNEL_TB + '|default_vxlan_tunnel')
+        tunnel_table = self.configdb.hgetall(VXLAN_TUNNEL_TB + '|default_vxlan_tunnel_v4')
         self.assertEqual(tunnel_table, {b'src_ip': b'34.53.1.0'})
         l.info("Tunnel table is %s", tunnel_table)
 
@@ -376,7 +376,7 @@ class ra_client_positive_tests(rest_api_client):
         r = self.delete_config_tunnel_decap_tunnel_type('vxlan')
         self.assertEqual(r.status_code, 204)
         # The delete is a no-op and should return 204, moreover the tunnel should not be deleted 
-        tunnel_table = self.configdb.hgetall(VXLAN_TUNNEL_TB + '|default_vxlan_tunnel')
+        tunnel_table = self.configdb.hgetall(VXLAN_TUNNEL_TB + '|default_vxlan_tunnel_v4')
         self.assertEqual(tunnel_table, {b'src_ip': b'34.53.1.0'})
 
 
@@ -406,7 +406,7 @@ class ra_client_positive_tests(rest_api_client):
 
         vrouter_table = self.configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         self.assertEqual(vrouter_table, {
-							b'vxlan_tunnel': b'default_vxlan_tunnel',
+							b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
 							b'vni': b'1001',
 							b'guid': b'vnet-guid-1'
 							})
@@ -447,7 +447,7 @@ class ra_client_positive_tests(rest_api_client):
              self.check_vrouter_exists("vnet-guid-"+str(i), 1000+i)
              vrouter_table = self.configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF +str(i))
              self.assertEqual(vrouter_table, {
-                     b'vxlan_tunnel': b'default_vxlan_tunnel',
+                     b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                      b'vni': b'100'+str(i),
                      b'guid': b'vnet-guid-'+str(i)
                      })
@@ -460,7 +460,7 @@ class ra_client_positive_tests(rest_api_client):
              self.check_vrouter_exists("vnet-guid-"+str(i+3), 1003+i)
              vrouter_table = self.configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF +str(i))
              self.assertEqual(vrouter_table, {
-                     b'vxlan_tunnel': b'default_vxlan_tunnel',
+                     b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                      b'vni': b'100'+str(i+3),
                      b'guid': b'vnet-guid-'+str(i+3)
                      })
@@ -470,7 +470,7 @@ class ra_client_positive_tests(rest_api_client):
              self.check_vrouter_exists("vnet-guid-"+str(i+6), 1006+i)
              vrouter_table = self.configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF +str(i+3))
              self.assertEqual(vrouter_table, {
-                     b'vxlan_tunnel': b'default_vxlan_tunnel',
+                     b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                      b'vni': b'100'+str(i+6),
                      b'guid': b'vnet-guid-'+str(i+6)
                      })

--- a/test/apitest.py
+++ b/test/apitest.py
@@ -213,6 +213,24 @@ class rest_api_client(unittest.TestCase):
         })
         self.assertEqual(rv.status_code, 204)
 
+    def post_generic_vxlan_v6_tunnel(self):
+        rv = self.post_config_tunnel_decap_tunnel_type('vxlan', {
+            'ip_addr': '2000:1000'
+        })
+        self.assertEqual(rv.status_code, 204)
+
+    def post_generic_default_vrouter_and_deps(self):
+        self.post_generic_vxlan_tunnel()
+        self.post_generic_vxlan_v6_tunnel()
+        rv = self.post_config_vrouter_vrf_id("vnet-default", {
+            'vnid': 8000
+        })
+        self.assertEqual(rv.status_code, 204)
+        rv = self.post_config_vrouter_vrf_id("vnet-default-v4", {
+            'vnid': 8000
+        })
+        self.assertEqual(rv.status_code, 204)
+
     def post_generic_vrouter_and_deps(self):
         self.post_generic_vxlan_tunnel()
         rv = self.post_config_vrouter_vrf_id("vnet-guid-1", {
@@ -414,6 +432,11 @@ class ra_client_positive_tests(rest_api_client):
     def  test_get_vrouter(self):
         self.post_generic_vrouter_and_deps()
         self.check_vrouter_exists("vnet-guid-1",1001)
+
+    def  test_default_vrouter(self):
+        self.post_generic_default_vrouter_and_deps()
+        self.check_vrouter_exists("vnet-default",8000)
+        self.check_vrouter_exists("vnet-default-v4",8000)
 
     def test_duplicate_vni(self):
         self.post_generic_vrouter_and_deps_duplicate()

--- a/test/restapi_client.py
+++ b/test/restapi_client.py
@@ -215,6 +215,25 @@ class RESTAPI_client:
         })
         assert rv.status_code == 204
 
+    def post_generic_vxlan_v6_tunnel(self):
+        rv = self.post_config_tunnel_decap_tunnel_type('vxlan', {
+            'ip_addr': '2000::1000'
+        })
+        assert rv.status_code == 204
+
+    def post_generic_default_vrouter_and_deps(self):
+        self.post_generic_vxlan_tunnel()
+        self.post_generic_vxlan_v6_tunnel()
+        rv = self.post_config_vrouter_vrf_id("Vnet-default", {
+            'vnid': 8000
+        })
+        assert rv.status_code == 204
+
+        rv = self.post_config_vrouter_vrf_id("Vnet-default-v4", {
+            'vnid': 8000
+        })
+        assert rv.status_code == 204
+
     def post_generic_vrouter_and_deps(self):
         self.post_generic_vxlan_tunnel()
         rv = self.post_config_vrouter_vrf_id("vnet-guid-1", {

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -119,7 +119,7 @@ class TestRestApiPositive:
         })
         assert r.status_code == 409
 
-        tunnel_table = configdb.hgetall(VXLAN_TUNNEL_TB + '|default_vxlan_tunnel')
+        tunnel_table = configdb.hgetall(VXLAN_TUNNEL_TB + '|default_vxlan_tunnel_v4')
         assert tunnel_table == {b'src_ip': b'34.53.1.0'}
         logging.info("Tunnel table is %s", tunnel_table)
 
@@ -129,7 +129,7 @@ class TestRestApiPositive:
         r = restapi_client.delete_config_tunnel_decap_tunnel_type('vxlan')
         assert r.status_code == 204
         # The delete is a no-op and should return 204, moreover the tunnel should not be deleted 
-        tunnel_table = configdb.hgetall(VXLAN_TUNNEL_TB + '|default_vxlan_tunnel')
+        tunnel_table = configdb.hgetall(VXLAN_TUNNEL_TB + '|default_vxlan_tunnel_v4')
         assert tunnel_table == {b'src_ip': b'34.53.1.0'}
 
 
@@ -163,7 +163,7 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         assert vrouter_table == {
-                                  b'vxlan_tunnel': b'default_vxlan_tunnel',
+                                  b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                                   b'vni': b'1001',
                                   b'guid': b'vnet-guid-1'
                                 }
@@ -178,7 +178,7 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         assert vrouter_table == {
-                                  b'vxlan_tunnel': b'default_vxlan_tunnel',
+                                  b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                                   b'vni': b'1001',
                                   b'guid': b'vnet-guid-1'
                                 }
@@ -200,7 +200,7 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         assert vrouter_table == {
-                    b'vxlan_tunnel': b'default_vxlan_tunnel',
+                    b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                     b'vni': b'1001',
                     b'guid': b'vnet-guid-1',
                     b'advertise_prefix': b'false'
@@ -213,7 +213,7 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '2')
         assert vrouter_table == {
-                    b'vxlan_tunnel': b'default_vxlan_tunnel',
+                    b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                     b'vni': b'1002',
                     b'guid': b'vnet-guid-2',
                     b'advertise_prefix': b'true'
@@ -231,7 +231,7 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         assert vrouter_table == {
-                    b'vxlan_tunnel': b'default_vxlan_tunnel',
+                    b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                     b'vni': b'1001',
                     b'guid': b'vnet-guid-1',
                     b'advertise_prefix': b'true',
@@ -248,7 +248,7 @@ class TestRestApiPositive:
 
         vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
         assert vrouter_table == {
-                    b'vxlan_tunnel': b'default_vxlan_tunnel',
+                    b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                     b'vni': b'2001',
                     b'guid': b'Vnet-default',
                     b'scope': b'default'
@@ -295,7 +295,7 @@ class TestRestApiPositive:
              self.check_vrouter_exists(restapi_client, "vnet-guid-"+str(i), 1000+i)
              vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF +str(i))
              assert vrouter_table == {
-                     b'vxlan_tunnel': b'default_vxlan_tunnel',
+                     b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                      b'vni': b'100'+str(i).encode(),
                      b'guid': b'vnet-guid-'+str(i).encode()
                      }
@@ -308,7 +308,7 @@ class TestRestApiPositive:
              self.check_vrouter_exists(restapi_client, "vnet-guid-"+str(i+3), 1003+i)
              vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF +str(i))
              assert vrouter_table == {
-                     b'vxlan_tunnel': b'default_vxlan_tunnel',
+                     b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                      b'vni': b'100'+str(i+3).encode(),
                      b'guid': b'vnet-guid-'+str(i+3).encode()
                      }
@@ -318,7 +318,7 @@ class TestRestApiPositive:
              self.check_vrouter_exists(restapi_client, "vnet-guid-"+str(i+6), 1006+i)
              vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF +str(i+3))
              assert vrouter_table == {
-                     b'vxlan_tunnel': b'default_vxlan_tunnel',
+                     b'vxlan_tunnel': b'default_vxlan_tunnel_v4',
                      b'vni': b'100'+str(i+6).encode(),
                      b'guid': b'vnet-guid-'+str(i+6).encode()
                      }


### PR DESCRIPTION
1. Support for both IPv4 and IPv6 tunnel for default VRF. IPv6 tunnel must use `Vnet-default` as Vnet name and IPv4 tunnel must use `Vnet-default-v4` as Vnet name.
2. When system has both V4 and V6 tunnel decap, NON-DEFAULT VRFs always choose V6 tunnel, whereas DEFAULT VRF chose v4 tunnel if VNET name in API is provided as - `Vnet-default-v4` and chose v6 tunnel if VNET name is provided as - `Vnet-default`
3. When system has only one type of tunnel, all Vnets chose the configured single tunnel (IPv4 or IPv6). No change to existing behavior. 
4. Only one decap tunnel of type V4 and one decap tunnel of type V6 is permitted. 