### PR TITLE
Fix race build option not supported issue in armhf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ export GOPATH=$(HOME)/go
 export GOBIN=$(GOPATH)/bin
 export GO111MODULE=on
 export GOFLAGS=-modcacherw
+RACE_OPTION := -race
+ifeq ($(CONFIGURED_ARCH),armhf)
+RACE_OPTION :=
+endif
 
 all: install build
 
@@ -16,10 +20,10 @@ install: build
 build: $(GOPATH)/bin/go-server-server $(GOPATH)/bin/go-server-server.test
 
 $(GOPATH)/bin/go-server-server: libcswsscommon $(GOPATH)/src/go-server-server/main.go
-	cd $(GOPATH)/src/go-server-server && $(GO) get -v && $(GO) build -race -v
+	cd $(GOPATH)/src/go-server-server && $(GO) get -v && $(GO) build $(RACE_OPTION) -v
 
 $(GOPATH)/bin/go-server-server.test: libcswsscommon $(GOPATH)/src/go-server-server/main.go
-	cd $(GOPATH)/src/go-server-server && $(GO) get -v && $(GO) test -race -c -covermode=atomic -coverpkg "go-server-server/go" -v -o $(GOPATH)/bin/go-server-server.test
+	cd $(GOPATH)/src/go-server-server && $(GO) get -v && $(GO) test $(RACE_OPTION) -c -covermode=atomic -coverpkg "go-server-server/go" -v -o $(GOPATH)/bin/go-server-server.test
 
 $(GOPATH)/src/go-server-server/main.go:
 	mkdir -p               $(GOPATH)/src

--- a/mseethrifttest/Makefile
+++ b/mseethrifttest/Makefile
@@ -1,13 +1,17 @@
 #FIXME: Create better rules
 #FIXME: Check and write all dependencies
 
+RACE_OPTION := -race
+ifeq ($(CONFIGURED_ARCH),armhf)
+RACE_OPTION :=
+endif
 
 .INTERMEDIATE: msee.thrift.intermediate
 
 all: client
 
 client: client.go ../mseethrift/msee.go
-	go build -race client.go
+	go build $(RACE_OPTION) client.go
 
 msee/constants.go msee/msee.go msee/ttypes.go: msee.thrift.intermediate
 	go get "git.apache.org/thrift.git/lib/go/thrift"


### PR DESCRIPTION
Fix race build option not supported issue in armhf
```
go-server-server
go build: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
```
