### PR TITLE
[build] Fix Makefile didn't set go build target file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install: build
 build: $(GOPATH)/bin/go-server-server $(GOPATH)/bin/go-server-server.test
 
 $(GOPATH)/bin/go-server-server: libcswsscommon $(GOPATH)/src/go-server-server/main.go
-	cd $(GOPATH)/src/go-server-server && $(GO) get -v && $(GO) build $(RACE_OPTION) -v
+	cd $(GOPATH)/src/go-server-server && $(GO) get -v && $(GO) build $(RACE_OPTION) -v -o $(GOPATH)/bin/go-server-server
 
 $(GOPATH)/bin/go-server-server.test: libcswsscommon $(GOPATH)/src/go-server-server/main.go
 	cd $(GOPATH)/src/go-server-server && $(GO) get -v && $(GO) test $(RACE_OPTION) -c -covermode=atomic -coverpkg "go-server-server/go" -v -o $(GOPATH)/bin/go-server-server.test


### PR DESCRIPTION
When upgrading golang from v1.15 to 1.19, the default build target is root of source folder.
Fix Makefile to support go1.19.