### PR TITLE
go.mod: bump go directive to 1.25.9

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -42,10 +42,9 @@ RUN rm -fr /debs
 # && make \
 # && make install
 
-RUN eatmydata apt-get install -y golang
-
-RUN eatmydata apt-get install -y golang-go \
- && ln -sf /usr/lib/go-1.19 /usr/local/go
+RUN wget -q https://dl.google.com/go/go1.25.9.linux-amd64.tar.gz -O /tmp/go.tar.gz \
+ && tar -C /usr/local -xzf /tmp/go.tar.gz \
+ && rm /tmp/go.tar.gz
 
 ENV GOROOT=/usr/local/go
 ENV PATH=$PATH:$GOROOT/bin

--- a/go-server-server/go.mod
+++ b/go-server-server/go.mod
@@ -1,6 +1,6 @@
 module go-server-server
 
-go 1.15
+go 1.25.9
 
 require (
 	github.com/comail/colog v0.0.0-20160416085026-fba8e7b1f46c

--- a/swsscommon/go.mod
+++ b/swsscommon/go.mod
@@ -1,3 +1,3 @@
 module swsscommon
 
-go 1.15
+go 1.25.9


### PR DESCRIPTION
#### Why I did it

Bump go directive from 1.15 to 1.25.9 to pick up Go stdlib security fixes.

##### Work item tracking
- Microsoft ADO:

#### How I did it

Update `go` directive in `go-server-server/go.mod` and `swsscommon/go.mod` from `1.15` to `1.25.9`.

#### How to verify it

Build go-server-server and confirm no build errors.
